### PR TITLE
Remove !important from h1 a, hn a, ...

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -356,7 +356,7 @@ h3 a,
 h4 a, 
 h5 a, 
 h6 a {
-  color: #2ba6cb !important;
+  color: #2ba6cb;
 }
 
 h1 a:active, 


### PR DESCRIPTION
!important directive prevents rule from working in Outlook 2007/2010/2013 
Since there is no pseudo-selector here, this rule will get inlined so the !important directive is useless in this case
