### PR TITLE
Removed invalid trailing comma from .one class

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -167,7 +167,7 @@ table.eleven center { min-width: 530px; }
 table.twelve center { min-width: 580px; }
 
 .body .columns td.one,
-.body .column td.one, { width: 8.333333% !important; }
+.body .column td.one { width: 8.333333% !important; }
 .body .columns td.two,
 .body .column td.two { width: 16.666666% !important; }
 .body .columns td.three,


### PR DESCRIPTION
This is a simple fix to remove a unnecessary trailing comma.

When the .one class is applied the width value isn't read properly therefor it applies 100% with on smaller displays and causes an undesired effect.
