### PR TITLE
HTML center mis-aligns grid

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -166,6 +166,19 @@ table.ten center { min-width: 480px; }
 table.eleven center { min-width: 530px; }
 table.twelve center { min-width: 580px; }
 
+table.one .panel center { min-width: 10px; }
+table.two .panel center { min-width: 60px; }
+table.three .panel center { min-width: 110px; }
+table.four .panel center { min-width: 160px; }
+table.five .panel center { min-width: 210px; }
+table.six .panel center { min-width: 260px; }
+table.seven .panel center { min-width: 310px; }
+table.eight .panel center { min-width: 360px; }
+table.nine .panel center { min-width: 410px; }
+table.ten .panel center { min-width: 460px; }
+table.eleven .panel center { min-width: 510px; }
+table.twelve .panel center { min-width: 560px; }
+
 .body .columns td.one,
 .body .column td.one { width: 8.333333% !important; }
 .body .columns td.two,


### PR DESCRIPTION
The docs suggest the use of HTML `<center>`, https://github.com/zurb/ink/blob/master/docs/components/grid.php#L187

![localhost4567eventsstandardday-1 html_20131128_161802](https://f.cloud.github.com/assets/154176/1637426/0d124d62-57ea-11e3-92a8-597c9db680b1.png)

This is generated with the following: https://gist.github.com/rjocoleman/7687456
CSS is Ink 1.0.4 only.

If the HTML `center` element is removed the grid behaves as expected.

**Update:** the placeholder.it of a 580px wide image is probably a bad choice, it's un-related though, litmus tests below.
Converted to a PR.
