### PR TITLE
.panel with .sub-columns

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -153,6 +153,19 @@ table.ten { width: 480px; }
 table.eleven { width: 530px; }
 table.twelve { width: 580px; }
 
+.panel table.one { width: 10px; }
+.panel table.two { width: 60px; }
+.panel table.three { width: 110px; }
+.panel table.four { width: 160px; }
+.panel table.five { width: 210px; }
+.panel table.six { width: 260px; }
+.panel table.seven { width: 310px; }
+.panel table.eight { width: 360px; }
+.panel table.nine { width: 410px; }
+.panel table.ten { width: 460px; }
+.panel table.eleven { width: 510px; }
+.panel table.twelve { width: 560px; }
+
 table.one center { min-width: 30px; }
 table.two center { min-width: 80px; }
 table.three center { min-width: 130px; }


### PR DESCRIPTION
I think this may be related to #32.

I've got a twelve column panel with some sub columns i.e: 
https://gist.github.com/rjocoleman/7762701

With the both the `.sub-columns` and `.panel` present it over-shoots the grid.
![with-panel](https://f.cloud.github.com/assets/154176/1660462/1bb43db2-5bbe-11e3-8e68-0ec838624822.png)

Without the `panel` the layout is as expected.
![without-panel](https://f.cloud.github.com/assets/154176/1660463/1c4aaa7c-5bbe-11e3-8454-78d22052745c.png)
