### PR TITLE
Update example titles to reflect actual class names

### DIFF
--- a/docs/examples/text-pad.html
+++ b/docs/examples/text-pad.html
@@ -66,7 +66,7 @@
                       <table class="six columns">
                         <tr>
                           <td class="left-text-pad">
-                            <h6>.text-pad-left</h6>
+                            <h6>.left-text-pad</h6>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dolor, adipisci eveniet distinctio vero doloremque repellendus dolores ex veritatis ipsum maiores quis non reprehenderit expedita cumque esse repudiandae alias aperiam earum.</p>
                           </td>
                           <td class="expander"></td>
@@ -79,7 +79,7 @@
                       <table class="six columns">
                         <tr>
                           <td class="right-text-pad">
-                            <h6>.text-pad-right</h6>
+                            <h6>.right-text-pad</h6>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dolor, adipisci eveniet distinctio vero doloremque repellendus dolores ex veritatis ipsum maiores quis non reprehenderit expedita cumque esse repudiandae alias aperiam earum.</p>
                           </td>
                           <td class="expander"></td>


### PR DESCRIPTION
The example padding headings were not matching up with the actual class names.
