### PR TITLE
expand .button a to fill width of parent

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -448,6 +448,9 @@ table.large-button td a {
   font-family: Helvetica, Arial, sans-serif;
   color: #ffffff;
   font-size: 16px;
+  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 table.tiny-button td a {


### PR DESCRIPTION
.button a is confusing because only the text is linked, though the full table has hover effect. This is confusing because the the user sees the hover change or clicks somewhere on the button, but there is no active/clickable link unless the cursor is over the linked text.
