### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2013 ZURB, inc.
+Copyright (c) 2014 ZURB, inc.
 
 MIT License
 


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
