### PR TITLE
allow tables to be displayed in email

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -618,8 +618,8 @@ body.outlook p {
     display: table !important;
   }
 
-  table[class="body"] table.columns td,
-  table[class="body"] table.column td {
+  table[class="body"] table.columns > tr > td,
+  table[class="body"] table.column > tr > td {
     width: 100% !important;
   }
 


### PR DESCRIPTION
I tried to display tableized data within a column, and wondered why the first column of the table always expanded to 100%.
