### PR TITLE
add comments explaining reset for .ExternalClass

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -17,7 +17,7 @@ body{
   padding:0;
 }
 
-  /* .ExternalClass applies to Hotmail and Outlook.com  */
+  /* .ExternalClass applies to Outlook.com (the artist formerly known as Hotmail)  */
   
 .ExternalClass { 
   width:100%;


### PR DESCRIPTION
In trying to remove unused styles in ink.css for my own instance, I found myself wondering about a few selectors, and where they apply such as `.ExternalClass` and the `img` resets. As I was unable to find any usage of .ExternalClass in the Ink [templates](https://github.com/zurb/ink/tree/master/templates) themselves, or even a reference in the [docs](http://zurb.com/ink/docs.php), it took a bit of Googling to figure out why they are even in there to know if I could remove them, or modify them.

So of course it turns out the `.ExternalClass` selector is specifically for Hotmail/Outlook.com which add that to your email markup after delivery.

It would be awesome if relevant bits like that were included as comments in the stylesheet for quick and easy reference.
