### PR TITLE
Remove td from typography

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -319,7 +319,7 @@ img.center {
 
 /* Typography */
 
-body, table.body, h1, h2, h3, h4, h5, h6, p, td { 
+body, table.body, h1, h2, h3, h4, h5, h6, p { 
   color: #222222;
   font-family: "Helvetica", "Arial", sans-serif; 
   font-weight: normal; 


### PR DESCRIPTION
Is this needed? I have a problem with inlining my CSS, because this rule conflicts with the td.wrapper padding.
Maybe the inliner is not totally correct, but this does solve my problem. (inliner: https://github.com/tijsverkoyen/CssToInlineStyles)
