### PR TITLE
Update table.columns margin

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -119,7 +119,7 @@ td.wrapper {
 
 table.columns,
 table.column {
-  margin: 0 auto;
+  margin: 0 auto 0 0;
 }
 
 table.columns td,


### PR DESCRIPTION
Set "table.columns, table.column" right margin to 0px.

This is to fix a problem which appears when using `offset-by-x` class and then columns don't add up to 12; after inlining the CSS the column table is then pulled too far right as it centres along the full row width left after the offset (rather than pulling to the left, so that the column rests just after the offset position). It is similar to #95, and should fix those that are using the officially documented offset technique.
