### PR TITLE
Fix center tags inside block grids

### DIFF
--- a/scss/grid/_block-grid.scss
+++ b/scss/grid/_block-grid.scss
@@ -29,12 +29,9 @@ $block-grid-gutter: $global-gutter !default;
   .up-#{$i} td {
     width: floor(($global-width - $i * $block-grid-gutter) / $i) !important;
   }
-}
 
-// Allow centering in block grids
-@for $i from 2 through $block-grid-max {
   .block-grid.up-#{$i} center,
   .block-grid.up-#{$i} center {
-    min-width: -zf-grid-calc-px($i, $block-grid-max, $global-width)-($block-grid-gutter*2);
+    min-width: floor(($global-width - $i * $block-grid-gutter) / $i) !important;
   }
 }

--- a/scss/grid/_block-grid.scss
+++ b/scss/grid/_block-grid.scss
@@ -30,8 +30,7 @@ $block-grid-gutter: $global-gutter !default;
     width: floor(($global-width - $i * $block-grid-gutter) / $i) !important;
   }
 
-  .block-grid.up-#{$i} center,
-  .block-grid.up-#{$i} center {
+  .up-#{$i} center {
     min-width: floor(($global-width - $i * $block-grid-gutter) / $i) !important;
   }
 }

--- a/scss/grid/_block-grid.scss
+++ b/scss/grid/_block-grid.scss
@@ -30,3 +30,11 @@ $block-grid-gutter: $global-gutter !default;
     width: floor(($global-width - $i * $block-grid-gutter) / $i) !important;
   }
 }
+
+// Allow centering in block grids
+@for $i from 2 through $block-grid-max {
+  .block-grid.up-#{$i} center,
+  .block-grid.up-#{$i} center {
+    min-width: -zf-grid-calc-px($i, $block-grid-max, $global-width)-($block-grid-gutter*2);
+  }
+}

--- a/test/visual/pages/center.html
+++ b/test/visual/pages/center.html
@@ -13,5 +13,218 @@
       </center>
     </columns>
   </row>
-</container>
+  <row>
+    <columns small="6" large="6" class="text-center">
+      <center>
+        <img src="http://placehold.it/150">
+      </center>
+    </columns>
+        <columns small="6" large="6" class="text-center">
+      <center>
+        <img src="http://placehold.it/150">
+      </center>
+    </columns>
+  </row>
 
+  <row>
+    <columns small="12">
+      <p class="text-center">Centering inside Block-Grid below</p>
+    </columns>
+  </row>
+
+  <block-grid up="2">
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+  </block-grid>
+
+  <block-grid up="3">
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+  </block-grid>
+
+  <block-grid up="4">
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+  </block-grid>
+
+  <block-grid up="5">
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+  </block-grid>
+
+  <block-grid up="6">
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+  </block-grid>
+
+  <block-grid up="7">
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+  </block-grid>
+
+  <block-grid up="8">
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+    <td>
+      <center style="border: 1px solid blue">
+        <img src="http://placehold.it/150" alt="">
+      </center>
+    </td>
+  </block-grid>
+</container>

--- a/test/visual/pages/center.html
+++ b/test/visual/pages/center.html
@@ -1,3 +1,9 @@
+<style>
+  .border {
+    border: 1px solid blue;
+  }
+</style>
+
 <container>
   <row>
     <columns small="12" large="12" class="text-center">
@@ -34,12 +40,12 @@
 
   <block-grid up="2">
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
@@ -47,17 +53,17 @@
 
   <block-grid up="3">
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
@@ -65,22 +71,22 @@
 
   <block-grid up="4">
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
@@ -88,27 +94,27 @@
 
   <block-grid up="5">
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
@@ -116,32 +122,32 @@
 
   <block-grid up="6">
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
@@ -149,37 +155,37 @@
 
   <block-grid up="7">
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
@@ -187,42 +193,42 @@
 
   <block-grid up="8">
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>
     <td>
-      <center style="border: 1px solid blue">
+      <center class="border">
         <img src="http://placehold.it/150" alt="">
       </center>
     </td>


### PR DESCRIPTION
This adjusts the `min-width` of the `center` tag inside Block-grids to match the width of the blocks.
Otherwise the `center` tag becomes the full width of the root container and breaks the layout.
