### PR TITLE
Add DIV to all Boilerplates / Templates

### DIFF
--- a/docs/layouts/default.html
+++ b/docs/layouts/default.html
@@ -31,7 +31,7 @@
 
       <div class="expanded row">
         <div class="medium-9 large-10 medium-push-3 large-push-2 columns">
-{{> body}}
+          {{> body}}
         </div>
         <div class="medium-3 large-2 medium-pull-9 large-pull-10 columns">
           {{> component-list}}

--- a/docs/pages/css-guide.md
+++ b/docs/pages/css-guide.md
@@ -168,7 +168,7 @@ Now that you have an inlined email, you'll need to test it in real email clients
 
 The most popular tool for testing emails is [Litmus](https://litmus.com/). All you have to do is paste in the HTML of an email, and you get a live preview in any email client you want.
 
-It's up to you to choose what email clients are important to test in, but you can [see our compatability list](compatibility.html) for recommendations.
+It's up to you to choose what email clients are important to test in, but you can [see our compatibility list](compatibility.html) for recommendations.
 
 ---
 

--- a/docs/pages/css-guide.md
+++ b/docs/pages/css-guide.md
@@ -109,7 +109,7 @@ Inside of your row (the innermost `<tr>`), add one column using this code:
 ```html
 <table class="row">
   <tr>
-    <th class="small-12 large-6 first columns ">
+    <th class="small-12 large-6 first columns">
       Column One
     </th>
     <th class="expander"></th>
@@ -124,10 +124,10 @@ Since this first column is half-width, we need a second one to go with it. *Afte
 ```html
 <table class="row">
   <tr>
-    <th class="small-12 large-6 first columns ">
+    <th class="small-12 large-6 first columns">
       Column One
     </th>
-    <th class="small-12 large-6 last columns ">
+    <th class="small-12 large-6 last columns">
       Column Two
     </th>
     <th class="expander"></th>

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -65,7 +65,7 @@ Get to know the pieces of Foundation.
     <strong>Buttons</strong>
     <p>Buttons with support for multiple sizes and colors.</p>
   </a></div>
-  <div class="column"><a href="button.html">
+  <div class="column"><a href="callout.html">
     <strong>Callout</strong>
     <p>Colored panels to use for sectioning or calls to action.</p>
   </a></div>

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -64,7 +64,6 @@ table.button {
   table {
 
     td {
-      width: auto !important;
       text-align: left;
       color: $button-color;
       background: $button-background;

--- a/scss/components/_type.scss
+++ b/scss/components/_type.scss
@@ -238,7 +238,7 @@ small {
 
 a {
   color: $anchor-color;
-  text-decoration: none;
+  text-decoration: $anchor-text-decoration;
 
   &:hover {
     color: $anchor-color-hover;

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -42,7 +42,7 @@ table {
   }
   
   &.spacer {
-      width: 100%;
+    width: 100%;
   }
 }
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -43,6 +43,9 @@ table {
   
   &.spacer {
     width: 100%;
+    td {
+      mso-line-height-rule: exactly;
+    }
   }
 }
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -115,16 +115,12 @@ th.column {
       width: -zf-grid-calc-px($i, $grid-column-count, $global-width) + ($global-gutter * 1.5);
     }
   }
-}
 
-@for $i from 1 through $grid-column-count {
   td.large-#{$i} center,
   th.large-#{$i} center {
     min-width: -zf-grid-calc-px($i, $grid-column-count, $global-width) - ($global-gutter * 2);
   }
-}
 
-@for $i from 1 through $grid-column-count {
   .body .columns td.large-#{$i},
   .body .column td.large-#{$i},
   .body .columns th.large-#{$i},

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -40,6 +40,10 @@ table {
     width: 100%;
     position: relative;
   }
+  
+  &.spacer {
+      width: 100%;
+  }
 }
 
 table.container table.row {

--- a/test/visual/assets
+++ b/test/visual/assets
@@ -1,1 +1,0 @@
-../../_build/assets

--- a/test/visual/pages/button-inky.html
+++ b/test/visual/pages/button-inky.html
@@ -6,7 +6,9 @@
 <container>
   <row>
     <columns small="12" large="12">
+      <center>
       <button href="http://zurb.com" class="tiny" href="http://zurb.com">I am a tiny button</button>
+      </center>
     </columns>
   </row>
   <row>

--- a/test/visual/pages/button.html
+++ b/test/visual/pages/button.html
@@ -12,13 +12,14 @@
                 <table>
                   <tr>
                     <td>
-                      <a href="https://zurb.com">I am a large button</a>
+                      <a href="https://zurb.com" style="width: 100% !important;">I am a large button</a>
                     </td>
                   </tr>
                 </table>
               </td>
             </tr>
           </table>
+
 
         </th>
       </tr>

--- a/test/visual/pages/button.html
+++ b/test/visual/pages/button.html
@@ -12,7 +12,7 @@
                 <table>
                   <tr>
                     <td>
-                      <a href="https://zurb.com" style="width: 100% !important;">I am a large button</a>
+                      <a href="https://zurb.com">I am a large button</a>
                     </td>
                   </tr>
                 </table>


### PR DESCRIPTION
In order to completely support Gmail on iOS, please add this code before the body tag to the boilerplates / templates in your new 2.0 repository:

`<div style="display:none; white-space:nowrap; font:15px courier; line-height:0;">
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; 
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; 
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
</div>`

Source: http://freshinbox.com/blog/gmail-ios-increases-email-font-sizes-again/
