### PR TITLE
fix: anchor text-decoration with $anchor-text-decoration variable

### DIFF
--- a/scss/components/_type.scss
+++ b/scss/components/_type.scss
@@ -238,7 +238,7 @@ small {
 
 a {
   color: $anchor-color;
-  text-decoration: none;
+  text-decoration: $anchor-text-decoration;
 
   &:hover {
     color: $anchor-color-hover;


### PR DESCRIPTION
enable to configure text-decoration property for anchors
