### PR TITLE
Add spacer component css rule in grid.scss

### DIFF
--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -42,7 +42,7 @@ table {
   }
   
   &.spacer {
-      width: 100%;
+    width: 100%;
   }
 }
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -43,6 +43,9 @@ table {
   
   &.spacer {
     width: 100%;
+    td {
+      mso-line-height-rule: exactly;
+    }
   }
 }
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -40,6 +40,10 @@ table {
     width: 100%;
     position: relative;
   }
+  
+  &.spacer {
+      width: 100%;
+  }
 }
 
 table.container table.row {


### PR DESCRIPTION
This PR is linked to the following Inky Pr : https://github.com/zurb/inky/pull/21
It adds the single css rule needed for the spacer element (100% width).

As a table, the component can be used pretty much anywhere but in my experience it's best to put it between rows or inside columns (between an image and a paragraph for instance).
