### PR TITLE
fixed grid width calculation

### DIFF
--- a/scss/util/_util.scss
+++ b/scss/util/_util.scss
@@ -18,5 +18,5 @@
 /// @param {number} $containerWidth - Width of the surrounding container, in pixels.
 /// @returns {number} A pixel width value.
 @function -zf-grid-calc-px($columnNumber, $totalColumns, $containerWidth) {
-  @return ($containerWidth / $totalColumns * $columnNumber - $global-gutter);
+  @return (($containerWidth - $global-gutter) / $totalColumns * $columnNumber - $global-gutter);
 }


### PR DESCRIPTION
Calcuation of grid elements width. Which was wrong by some pixels causing strange and sometimes unequals widths.

I.e. two columns width the class large-6: First column is 2px wider than second one (caused by setting to large widths causing the browser to set some strange widths fitting the container)
