### PR TITLE
Fix img height for visibility classes

### DIFF
--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -11,15 +11,16 @@ table.body table.container .hide-for-large {
   width:0;
   mso-hide:all; // hide selected elements in Outlook 2007-2013
   overflow:hidden;
-  max-height: 0px; 
+  max-height: 0px;
   font-size: 0;
   width: 0px;
-  line-height: 0; 
+  line-height: 0;
 
   @media only screen and (max-width: #{$global-breakpoint}) {
     display: block !important;
     width: auto !important;
     overflow: visible !important;
+    max-height: none !important;
   }
 }
 
@@ -50,8 +51,7 @@ table.body table.container .show-for-large {
 //   width: 0;
 // }
 // in media query
-// img { 
-//   max-height: none !important; 
-//   width: auto !important; 
+// img {
+//   max-height: none !important;
+//   width: auto !important;
 // }
-


### PR DESCRIPTION
I'm using two different images in my template, when swapping to the mobile version, `max-height: 0px;` was preventing the image from displaying.

```
<img src="https://www.fillmurray.com/290/290" class="show-for-large" alt=""/>
<img src="https://www.fillmurray.com/600/300" class="hide-for-large" alt=""/>
```
