### PR TITLE
Don't do !important on the button width

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -57,7 +57,7 @@ $button-radius: $global-radius !default;
 $button-rounded: $global-rounded !default;
 
 table.button {
-  width: auto !important;
+  width: auto;
   margin: $button-margin;
   Margin: $button-margin;
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -68,7 +68,7 @@ td.columns,
 td.column,
 th.columns,
 th.column {
-  table {
+  table:not(.button) {
     width: 100%;
   }
 }


### PR DESCRIPTION
We shouldn't do `!important` on the button width cause that prevents us from custom styling it.

Example case, if you want your buttons to be 100% width on mobile devices but auto width on regular screens? With the current styling you can't achieve this because the scss is parsed to inline css with `width: 100% !important` which has the highest priority when rendering.
