### PR TITLE
Clean up, use self-closing tags in XHTML

### DIFF
--- a/dist/foundation.css
+++ b/dist/foundation.css
@@ -746,9 +746,8 @@ table.body table.container .hide-for-large {
   width: 0;
   mso-hide: all;
   overflow: hidden;
-  max-height: 0px;
+  max-height: 0;
   font-size: 0;
-  width: 0px;
   line-height: 0; }
   @media only screen and (max-width: 596px) {
     table.body table.container .hide-for-large {
@@ -923,7 +922,7 @@ table.button {
       text-decoration: none;
       display: inline-block;
       padding: 8px 16px 8px 16px;
-      border: 0px solid #2199e8;
+      border: 0 solid #2199e8;
       border-radius: 3px; }
   table.button.radius table td {
     border-radius: 3px;
@@ -988,7 +987,7 @@ table.button:active table td {
 table.button:hover table a,
 table.button:visited table a,
 table.button:active table a {
-  border: 0px solid #147dc2; }
+  border: 0 solid #147dc2; }
 
 table.button.secondary table td {
   background: #777777;
@@ -997,14 +996,14 @@ table.button.secondary table td {
 
 table.button.secondary table a {
   color: #fefefe;
-  border: 0px solid #777777; }
+  border: 0 solid #777777; }
 
 table.button.secondary:hover table td {
   background: #919191;
   color: #fefefe; }
 
 table.button.secondary:hover table a {
-  border: 0px solid #919191; }
+  border: 0 solid #919191; }
 
 table.button.secondary:hover table td a {
   color: #fefefe; }
@@ -1020,26 +1019,26 @@ table.button.success table td {
   border: 2px solid #3adb76; }
 
 table.button.success table a {
-  border: 0px solid #3adb76; }
+  border: 0 solid #3adb76; }
 
 table.button.success:hover table td {
   background: #23bf5d; }
 
 table.button.success:hover table a {
-  border: 0px solid #23bf5d; }
+  border: 0 solid #23bf5d; }
 
 table.button.alert table td {
   background: #ec5840;
   border: 2px solid #ec5840; }
 
 table.button.alert table a {
-  border: 0px solid #ec5840; }
+  border: 0 solid #ec5840; }
 
 table.button.alert:hover table td {
   background: #e23317; }
 
 table.button.alert:hover table a {
-  border: 0px solid #e23317; }
+  border: 0 solid #e23317; }
 
 table.callout {
   margin-bottom: 16px;

--- a/docs/pages/typography.md
+++ b/docs/pages/typography.md
@@ -69,5 +69,5 @@ Links are very standard, and the color is preset to the Foundation primary color
 Use dividers to define thematic breaks between paragraphs or sections of your email.
 
 ```
-<hr>
+<hr/>
 ```

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -77,7 +77,7 @@ table.button {
         text-decoration: none;
         display: inline-block;
         padding: map-get($button-padding, default);
-        border: 0px solid $button-background;
+        border: 0 solid $button-background;
         border-radius: $button-radius;
       }
     }
@@ -178,7 +178,7 @@ table.button:visited,
 table.button:active {
   table {
     a {
-      border: 0px solid darken($button-background, 10%);
+      border: 0 solid darken($button-background, 10%);
     }
   }
 }
@@ -193,7 +193,7 @@ table.button.secondary {
 
     a {
       color: $button-color;
-      border: 0px solid $secondary-color;
+      border: 0 solid $secondary-color;
     }
   }
 }
@@ -206,7 +206,7 @@ table.button.secondary:hover {
     }
 
     a {
-      border: 0px solid lighten($secondary-color, 10%);
+      border: 0 solid lighten($secondary-color, 10%);
     }
   }
 }
@@ -243,7 +243,7 @@ table.button.success {
     }
 
     a {
-      border: 0px solid $success-color;
+      border: 0 solid $success-color;
     }
   }
 }
@@ -255,7 +255,7 @@ table.button.success:hover {
     }
 
     a {
-      border: 0px solid darken($success-color, 10%);
+      border: 0 solid darken($success-color, 10%);
     }
   }
 }
@@ -268,7 +268,7 @@ table.button.alert {
     }
 
     a {
-      border: 0px solid $alert-color;
+      border: 0 solid $alert-color;
     }
   }
 }
@@ -280,7 +280,7 @@ table.button.alert:hover {
     }
 
     a {
-      border: 0px solid darken($alert-color, 10%);
+      border: 0 solid darken($alert-color, 10%);
     }
   }
 }

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -11,9 +11,9 @@ table.body table.container .hide-for-large {
   width:0;
   mso-hide:all; // hide selected elements in Outlook 2007-2013
   overflow:hidden;
-  max-height: 0px; 
+  max-height: 0;
   font-size: 0;
-  width: 0px;
+  width: 0;
   line-height: 0; 
 
   @media only screen and (max-width: #{$global-breakpoint}) {

--- a/templates/drip.html
+++ b/templates/drip.html
@@ -40,7 +40,7 @@
     </columns>
   </row>
 
-  <hr>
+  <hr/>
 
   <row>
     <columns>
@@ -54,7 +54,7 @@
   <row class="collapsed footer">
     <columns>
       <spacer size="16"></spacer>
-      <p class="text-center">@copywrite nobody<br>
+      <p class="text-center">@copywrite nobody<br/>
       <a href="#">hello@nocopywrite.com</a> | <a href="#">Manage Email Notifications</a> | <a href="#">Unsubscribe</a></p>
       <center>
         <menu>

--- a/templates/marketing.html
+++ b/templates/marketing.html
@@ -67,7 +67,7 @@
   <row class="collapsed footer">
     <columns>
       <spacer size="16"></spacer>
-      <p class="text-center">@copywrite nobody<br>
+      <p class="text-center">@copywrite nobody<br/>
       <a href="#">hello@nocopywrite.com</a> | <a href="#">Manage Email Notifications</a> | <a href="#">Unsubscribe</a></p>
       <center>
         <menu>

--- a/templates/order.html
+++ b/templates/order.html
@@ -21,25 +21,25 @@
         <row>
           <columns large="6">
             <p>
-              <strong>Payment Method</strong><br>
+              <strong>Payment Method</strong><br/>
               Dubloons
             </p>
             <p>
-              <strong>Email Address</strong><br>
+              <strong>Email Address</strong><br/>
               thecapn@pirates.org
             </p>
             <p>
-              <strong>Order ID</strong><br>
+              <strong>Order ID</strong><br/>
               239235983749636
             </p>
           </columns>
           <columns large="6">
             <p>
-              <strong>Shipping Method</strong><br>
-              Boat (1&ndash;2 weeks)<br>
-              <strong>Shipping Address</strong><br>
-              Captain Price<br>
-              123 Maple Rd<br>
+              <strong>Shipping Method</strong><br/>
+              Boat (1&ndash;2 weeks)<br/>
+              <strong>Shipping Address</strong><br/>
+              Captain Price<br/>
+              123 Maple Rd<br/>
               Campbell, CA 95112
             </p>
           </columns>
@@ -59,7 +59,7 @@
         </tr>
       </table>
 
-      <hr>
+      <hr/>
 
       <h4>What's Next?</h4>
 
@@ -72,13 +72,13 @@
     </columns>
     <columns large="3">
       <p>
-        Call us at 800.555.1923<br>
+        Call us at 800.555.1923<br/>
         Email us at support@discount.boat
       </p>
     </columns>
     <columns large="3">
       <p>
-        123 Maple Rd<br>
+        123 Maple Rd<br/>
         Campbell, CA 95112
       </p>
     </columns>

--- a/templates/password.html
+++ b/templates/password.html
@@ -38,7 +38,7 @@
       <p class="text-center">It happens. Click the link below to reset your password.</p>
       <button class="large expand" href="#">Reset Password</button>
 
-      <hr>
+      <hr/>
 
       <p><small>You're getting this email because you've signed up for email updates. If you want to opt-out of future emails, <a href="#">unsubscribe here</a>.</small></p>
     </columns>

--- a/test/visual/_template.html
+++ b/test/visual/_template.html
@@ -2,8 +2,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width"/>
-  <link rel="stylesheet" href="../assets/css/foundation.css">
+  <meta name="viewport" content="width=device-width" />
+  <title>Title</title>
+  <link rel="stylesheet" href="../assets/css/foundation.css" />
 </head>
 
 <body>

--- a/test/visual/pages/alignment.html
+++ b/test/visual/pages/alignment.html
@@ -27,12 +27,12 @@
       <h4 class="text-right">Right Text</h4>
       <p class="text-left">Left Text</p>
       <h4 class="text-left">Left Text</h4>
-      <br>
+      <br/>
       <p>Center on all clients</p>
       <center>
         <img src="http://placehold.it/200?text=center" alt="">
       </center>
-      <br>
+      <br/>
       <p>Center on all clients except Outlook 20017, 10, 13</p>
       <img class="float-center" src="http://placehold.it/200?text=center" alt="">
       <img class="float-right" src="http://placehold.it/200?text=right" alt="">

--- a/test/visual/pages/basic.html
+++ b/test/visual/pages/basic.html
@@ -14,11 +14,11 @@
 <container>
   <row>
     <columns>
-      <br>
+      <br/>
       <center>
         <img src="http://placehold.it/200x50">
       </center>
-      <br>
+      <br/>
       <h1>Hi, Susan Calvin</h1>
       <p class="lead">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magni, iste, amet consequatur a veniam.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ut optio nulla et, fugiat. Maiores accusantium nostrum asperiores provident, quam modi ex inventore dolores id aspernatur architecto odio minima perferendis, explicabo. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima quos quasi itaque beatae natus fugit provident delectus, magnam laudantium odio corrupti sit quam. Optio aut ut repudiandae velit distinctio asperiores?</p>

--- a/test/visual/pages/drip-treehouse.html
+++ b/test/visual/pages/drip-treehouse.html
@@ -12,7 +12,7 @@
     </columns>
   </row>
 
-  <hr>
+  <hr/>
 
   <row>
     <columns>
@@ -25,7 +25,7 @@
 
   <row class="collapsed footer">
     <columns>
-      <p class="text-center">@Funhouse Island Inc<br>
+      <p class="text-center">@Funhouse Island Inc<br/>
       <a href="#">hello@Funhouse.com</a> | <a href="#">Manage Email Notifications</a> | <a href="#">Unsubscribe</a></p>
       <center>
         <menu>

--- a/test/visual/pages/drip.html
+++ b/test/visual/pages/drip.html
@@ -10,13 +10,13 @@
 
 <container class="body-drip">
 
-  <br>
+  <br/>
 
   <center>
     <img src="http://placehold.it/120/663399" alt="">
   </center>
 
-  <br>
+  <br/>
 
   <row>
     <columns>
@@ -25,7 +25,7 @@
     </columns>
   </row>
 
-  <hr>
+  <hr/>
 
   <row>
     <columns>
@@ -38,8 +38,8 @@
 
   <row class="collapsed footer-drip">
     <columns>
-      <br>
-      <p class="text-center">@copywrite nobody<br>
+      <br/>
+      <p class="text-center">@copywrite nobody<br/>
       <a href="#">hello@nocopywrite.com</a> | <a href="#">Manage Email Notifications</a> | <a href="#">Unsubscribe</a></p>
       <center>
         <menu>

--- a/test/visual/pages/hero.html
+++ b/test/visual/pages/hero.html
@@ -14,18 +14,18 @@
 <container>
   <row>
     <columns>
-      <br>
+      <br/>
       <h1>Hi, Elijah Baily</h1>
       <p class="lead">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nisi impedit sapiente delectus molestias quia.</p>
       <img src="http://placehold.it/580x300" alt="">
-      <br><br>
+      <br/><br/>
       <callout class="primary">
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam assumenda, praesentium qui vitae voluptate dolores. <a href="#">Click it!</a></p>
       </callout>
       <h2>Title Ipsum <small>This is a note.</small></h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nisi repellat, harum. Quas nobis id aut, aspernatur, sequi tempora laborum corporis cum debitis, ullam, dolorem dolore quisquam aperiam! Accusantium, ullam, nesciunt. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ducimus consequuntur commodi, aut sed, quas quam optio accusantium recusandae nesciunt, architecto veritatis. Voluptatibus sunt esse dolor ipsum voluptates, assumenda quisquam.</p>
       <button class="large" href="#">Click Me!</button>
-      <br>
+      <br/>
       <callout class="secondary">
         <row>
           <columns large="6">

--- a/test/visual/pages/newsletter.html
+++ b/test/visual/pages/newsletter.html
@@ -5,7 +5,7 @@
       <center>
         <img src="http://placehold.it/500x200">
       </center>
-      <br><br><br>
+      <br/><br/><br/>
       <p class="lead">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsa itaque illo doloribus soluta expedita dolores commodi fuga odit.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto reiciendis eos magni deleniti accusamus tempore, consectetur! Maxime amet, exercitationem nihil fugit eius esse voluptatum ab incidunt minima, saepe reiciendis ipsum.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto reiciendis eos magni deleniti accusamus tempore, consectetur! Maxime amet, exercitationem nihil fugit eius esse voluptatum ab incidunt minima, saepe reiciendis ipsum.</p>

--- a/test/visual/pages/order.html
+++ b/test/visual/pages/order.html
@@ -8,25 +8,25 @@
         <row>
           <columns large="6">
             <p>
-              <strong>Payment Method</strong><br>
+              <strong>Payment Method</strong><br/>
               Dubloons
             </p>
             <p>
-              <strong>Email Address</strong><br>
+              <strong>Email Address</strong><br/>
               thecapn@pirates.org
             </p>
             <p>
-              <strong>Order ID</strong><br>
+              <strong>Order ID</strong><br/>
               239235983749636
             </p>
           </columns>
           <columns large="6">
             <p>
-              <strong>Shipping Method</strong><br>
-              Boat (1&ndash;2 weeks)<br>
-              <strong>Shipping Address</strong><br>
-              Captain Price<br>
-              123 Maple Rd<br>
+              <strong>Shipping Method</strong><br/>
+              Boat (1&ndash;2 weeks)<br/>
+              <strong>Shipping Address</strong><br/>
+              Captain Price<br/>
+              123 Maple Rd<br/>
               Campbell, CA 95112
             </p>
           </columns>
@@ -57,13 +57,13 @@
     </columns>
     <columns large="3">
       <p>
-        Call us at 800.555.1923<br>
+        Call us at 800.555.1923<br/>
         Email us at support@discount.boat
       </p>
     </columns>
     <columns large="3">
       <p>
-        123 Maple Rd<br>
+        123 Maple Rd<br/>
         Campbell, CA 95112
       </p>
     </columns>

--- a/test/visual/pages/password.html
+++ b/test/visual/pages/password.html
@@ -13,7 +13,7 @@
       <p class="text-center">It happens. Click the link below to reset your password.</p>
       <button class="large expand" href="#">Reset Password</button>
 
-      <hr>
+      <hr/>
 
       <p><small>You're getting this email because you've signed up for email updates. If you want to opt-out of future emails, <a href="#">unsubscribe here</a>.</small></p>
     </columns>

--- a/test/visual/pages/sidebar-hero.html
+++ b/test/visual/pages/sidebar-hero.html
@@ -12,7 +12,7 @@
 </div>
 
 <container>
-  <br>
+  <br/>
   <row>
     <columns>
       <h1>Hi, Elijah Baily</h1>


### PR DESCRIPTION
This is an updated replacement PR for #93 that targeted Ink rather than FM2.

I've seen conflicting advice about PR targets - the default PR content says to target `2.0`, but I've seen advice from committers in other PRs to target `develop`, so I've done that.

Various clean-ups have accumulated in this PR:
- Use self-closing tags in XHTML (solves major breaks in Outlook)
- Remove units from 0 values (let me know if this is incorrect - at least it's now consistent!)
- Remove a duplicate width property
- Fix a wrong padding selector
- Add missing `title` tag

See #93 for more details.
