### PR TITLE
Making button text color change based on background lightness

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -50,6 +50,10 @@ $white: #fefefe !default;
 /// @type Color
 $pre-color: #ff6908 !default;
 
+/// Threshhold to dedermine whether a color is light or dark
+/// @type Number
+$color-threshhold: 40 !default;
+
 /// Width of the container.
 /// @type Number
 $global-width: 580px !default;

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -50,9 +50,9 @@ $white: #fefefe !default;
 /// @type Color
 $pre-color: #ff6908 !default;
 
-/// Threshhold to dedermine whether a color is light or dark
+/// Threshold to determine whether a color is light or dark.
 /// @type Number
-$color-threshhold: 40 !default;
+$threshold: 40 !default;
 
 /// Width of the container.
 /// @type Number

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -34,7 +34,7 @@ $button-color-alt: $medium-gray !default;
 
 /// Threshhold to dedermine whether a color is light or dark
 /// @type Number
-$color-threshhold: 40 !default;
+$threshold: 40 !default;
 
 /// Font weight of buttons.
 /// @type Weight
@@ -69,7 +69,7 @@ table.button {
 
     td {
       text-align: left;
-      @if (lightness($button-background) > $color-threshhold){
+      @if (lightness($button-background) > $threshold){
         color: $button-color-alt;
       }
       @else {
@@ -82,7 +82,7 @@ table.button {
         font-family: $body-font-family;
         font-size: map-get($button-font-size, default);
         font-weight: $button-font-weight;
-        @if (lightness($button-background) > $color-threshhold){
+        @if (lightness($button-background) > $threshold){
           color: $button-color-alt;
         }
         @else {
@@ -120,7 +120,7 @@ table.button.small table tr td a:visited,
 table.button.large:hover table tr td a,
 table.button.large:active table tr td a,
 table.button.large table tr td a:visited {
-  @if (lightness($button-background) > $color-threshhold){
+  @if (lightness($button-background) > $threshold){
     color: $button-color-alt;
   }
   @else {
@@ -223,7 +223,7 @@ table.button.secondary {
     &:active table tr td,
     &:visited table tr td {
       background: $secondary-color;
-      @if (lightness($secondary-color) > $color-threshhold){
+      @if (lightness($secondary-color) > $threshold){
         color: $button-color-alt;
       }
       @else {
@@ -231,7 +231,7 @@ table.button.secondary {
       }
       border: 2px solid $secondary-color;
       a {
-        @if (lightness($secondary-color) > $color-threshhold){
+        @if (lightness($secondary-color) > $threshold){
           color: $button-color-alt;
         }
         @else {
@@ -241,7 +241,7 @@ table.button.secondary {
       }
     }
     &:hover table tr td {
-      @if (lightness($secondary-color) > $color-threshhold){
+      @if (lightness($secondary-color) > $threshold){
         background: lighten($secondary-color, 10%);
         color: $button-color-alt;
       }
@@ -250,7 +250,7 @@ table.button.secondary {
         color: $button-color;
       }
       a {
-        @if (lightness($secondary-color) > $color-threshhold){
+        @if (lightness($secondary-color) > $threshold){
           color: $button-color-alt;
           border: 0px solid lighten($secondary-color, 10%);
         }

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -32,6 +32,10 @@ $button-color: $white !default;
 /// @type Color
 $button-color-alt: $medium-gray !default;
 
+/// Threshhold to dedermine whether a color is light or dark
+/// @type Number
+$color-threshhold: 40 !default;
+
 /// Font weight of buttons.
 /// @type Weight
 $button-font-weight: bold !default;
@@ -65,7 +69,12 @@ table.button {
 
     td {
       text-align: left;
-      color: $button-color;
+      @if (lightness($button-background) > $color-threshhold){
+        color: $button-color-alt;
+      }
+      @else {
+        color: $button-color;
+      }
       background: $button-background;
       border: $button-border;
 
@@ -73,7 +82,12 @@ table.button {
         font-family: $body-font-family;
         font-size: map-get($button-font-size, default);
         font-weight: $button-font-weight;
-        color: $button-color;
+        @if (lightness($button-background) > $color-threshhold){
+          color: $button-color-alt;
+        }
+        @else {
+          color: $button-color;
+        }
         text-decoration: none;
         display: inline-block;
         padding: map-get($button-padding, default);
@@ -106,7 +120,12 @@ table.button.small table tr td a:visited,
 table.button.large:hover table tr td a,
 table.button.large:active table tr td a,
 table.button.large table tr td a:visited {
-  color: $button-color;
+  @if (lightness($button-background) > $color-threshhold){
+    color: $button-color-alt;
+  }
+  @else {
+    color: $button-color;
+  }
 }
 
 table.button.tiny {
@@ -173,64 +192,73 @@ table.button:active {
   }
 }
 
+
 table.button:hover,
 table.button:visited,
 table.button:active {
   table {
-    a {
+    td {
+      @if (lightness($button-background) > 50){
+        background: lighten($button-background, 10%);
+        color: $button-color-alt;
+      }
+      @else {
+        background: darken($button-background, 10%);
+        color: $button-color;
+      }
+    }
+    a{
       border: 0 solid darken($button-background, 10%);
     }
   }
 }
 
+
 table.button.secondary {
-  table {
-    td {
+  &,
+  &.tiny,
+  &.small,
+  &.large{
+    table tr td,
+    &:active table tr td,
+    &:visited table tr td {
       background: $secondary-color;
-      color: $button-color;
-      border: 0px solid $secondary-color;
+      @if (lightness($secondary-color) > $color-threshhold){
+        color: $button-color-alt;
+      }
+      @else {
+        color: $button-color;
+      }
+      border: 2px solid $secondary-color;
+      a {
+        @if (lightness($secondary-color) > $color-threshhold){
+          color: $button-color-alt;
+        }
+        @else {
+          color: $button-color;
+        }
+        border: 0px solid $secondary-color;
+      }
     }
-
-    a {
-      color: $button-color;
-      border: 0 solid $secondary-color;
-    }
-  }
-}
-
-table.button.secondary:hover {
-  table {
-    td {
-      background: lighten($secondary-color, 10%);
-      color: $button-color;
-    }
-
-    a {
-      border: 0 solid lighten($secondary-color, 10%);
-    }
-  }
-}
-
-table.button.secondary:hover {
-  table {
-    td a {
-      color: $button-color;
-    }
-  }
-}
-
-table.button.secondary:active {
-  table {
-    td a {
-      color: $button-color;
-    }
-  }
-}
-
-table.button.secondary {
-  table {
-    td a:visited {
-      color: $button-color;
+    &:hover table tr td {
+      @if (lightness($secondary-color) > $color-threshhold){
+        background: lighten($secondary-color, 10%);
+        color: $button-color-alt;
+      }
+      @else {
+        background: darken($secondary-color, 10%);
+        color: $button-color;
+      }
+      a {
+        @if (lightness($secondary-color) > $color-threshhold){
+          color: $button-color-alt;
+          border: 0px solid lighten($secondary-color, 10%);
+        }
+        @else {
+          color: $button-color;
+          border: 0px solid darken($secondary-color, 10%);
+        }
+      }
     }
   }
 }

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -27,6 +27,7 @@ $dark-gray: #8a8a8a;
 $black: #0a0a0a;
 $white: #fefefe;
 $pre-color: #ff6908;
+$color-threshhold: 40;
 $global-width: 580px;
 $global-width-small: 95%;
 $global-gutter: 16px;
@@ -143,4 +144,3 @@ $thumbnail-shadow: 0 0 0 1px rgba($black, 0.2);
 $thumbnail-shadow-hover: 0 0 6px 1px rgba($primary-color, 0.5);
 $thumbnail-transition: box-shadow 200ms ease-out;
 $thumbnail-radius: $global-radius;
-

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -27,7 +27,7 @@ $dark-gray: #8a8a8a;
 $black: #0a0a0a;
 $white: #fefefe;
 $pre-color: #ff6908;
-$color-threshhold: 40;
+$threshold: 40;
 $global-width: 580px;
 $global-width-small: 95%;
 $global-gutter: 16px;


### PR DESCRIPTION
These are the same changes from #438 but onto the 2.2 branch instead of the development one.
- Added a setting for color threshhold (default is 50).
- Added some checks for button color background to determine if the button should have the alternate color or not.
- Simplified code somewhat using "&" (and fixed a bug where non-standard sized buttons were incorrectly inheriting the standard button text color)
