### PR TITLE
Add th.text-center styling

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -90,7 +90,6 @@ $global-rounded: 500px !default;
 /// @type String
 $global-breakpoint: $global-width + $global-gutter !default;
 
-
 .wrapper {
   width: 100%;
 }

--- a/scss/components/_alignment.scss
+++ b/scss/components/_alignment.scss
@@ -7,6 +7,7 @@
 ////
 
 table.text-center,
+th.text-center,
 td.text-center,
 h1.text-center,
 h2.text-center,

--- a/scss/components/_alignment.scss
+++ b/scss/components/_alignment.scss
@@ -6,40 +6,28 @@
 /// @group alignment
 ////
 
-table.text-center,
-th.text-center,
-td.text-center,
-h1.text-center,
-h2.text-center,
-h3.text-center,
-h4.text-center,
-h5.text-center,
-h6.text-center,
-p.text-center,
-span.text-center {
-  text-align: center;
-}
+table,
+th,
+td,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+span {
+  &.text-center {
+    text-align: center;
+  }
 
-h1.text-left,
-h2.text-left,
-h3.text-left,
-h4.text-left,
-h5.text-left,
-h6.text-left,
-p.text-left,
-span.text-left {
-  text-align: left;
-}
+  &.text-left {
+    text-align: left;
+  }
 
-h1.text-right,
-h2.text-right,
-h3.text-right,
-h4.text-right,
-h5.text-right,
-h6.text-right,
-p.text-right,
-span.text-right {
-  text-align: right;
+  &.text-right {
+    text-align: right;
+  }
 }
 
 span.text-center {
@@ -86,13 +74,15 @@ img.text-center {
   text-align: center;
 }
 
-table.float-center,
-td.float-center,
-th.float-center {
-  margin: 0 auto;
-  Margin: 0 auto;
-  float: none;
-  text-align: center;
+table,
+td,
+th {
+  &.float-center {
+    margin: 0 auto;
+    Margin: 0 auto;
+    float: none;
+    text-align: center;
+  }
 }
 
 

--- a/scss/components/_alignment.scss
+++ b/scss/components/_alignment.scss
@@ -66,7 +66,7 @@ img.float-right {
   text-align: right;
 }
 
-img.float-center, 
+img.float-center,
 img.text-center {
   margin: 0 auto;
   Margin: 0 auto;

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -9,19 +9,19 @@
 /// Padding inside buttons at various sizes.
 /// @type Map
 $button-padding: (
-  tiny: 4px 8px 4px 8px,
-  small: 5px 10px 5px 10px,
-  default: 8px 16px 8px 16px,
-  large: 10px 20px 10px 20px,
+        tiny: 4px 8px 4px 8px,
+        small: 5px 10px 5px 10px,
+        default: 8px 16px 8px 16px,
+        large: 10px 20px 10px 20px,
 ) !default;
 
 /// Font sizes of buttons at various sizes.
 /// @type Map
 $button-font-size: (
-  tiny: 10px,
-  small: 12px,
-  default: 16px,
-  large: 20px,
+        tiny: 10px,
+        small: 12px,
+        default: 16px,
+        large: 20px,
 ) !default;
 
 /// Text color of buttons.

--- a/scss/components/_media-query.scss
+++ b/scss/components/_media-query.scss
@@ -30,7 +30,7 @@
     box-sizing: border-box;
     padding-left: $global-gutter !important;
     padding-right: $global-gutter !important;
-    
+
     // Nested columns won't double the padding
     .column,
     .columns {
@@ -70,7 +70,7 @@
   @for $i from 1 through ($grid-column-count - 1) {
     table.body td.small-offset-#{$i},
     table.body th.small-offset-#{$i} {
-    //1.5 takes in effect a whole empty cell.
+      //1.5 takes in effect a whole empty cell.
       margin-left: -zf-grid-calc-pct($i, $grid-column-count) !important;
       Margin-left: -zf-grid-calc-pct($i, $grid-column-count) !important;
     }
@@ -94,14 +94,14 @@
   //menu
   table.menu {
     width: 100% !important;
-    
+
     td,
     th {
       width: auto !important;
       display: inline-block !important;
     }
 
-    &.vertical, 
+    &.vertical,
     &.small-vertical {
       td,
       th {
@@ -114,7 +114,6 @@
   table.menu[align="center"] {
     width: auto !important;
   }
-
 
   // expands buttons for small only
   table.button.small-expand,

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -18,17 +18,16 @@ $menu-item-gutter: 10px !default;
 /// @type Color
 $menu-item-color: $primary-color !default;
 
-
 table.menu {
   width: $global-width;
 
   td.menu-item,
-  th.menu-item{
+  th.menu-item {
     padding: $menu-item-padding;
     padding-right: $menu-item-gutter;
 
     a {
-      color: $menu-item-color; 
+      color: $menu-item-color;
     }
   }
 }

--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -323,16 +323,16 @@ hr {
 
 // preheader styles
 span.preheader {
-  display:none !important;
-  visibility:hidden;
-  mso-hide:all !important;
-  font-size:1px;
+  display: none !important;
+  visibility: hidden;
+  mso-hide: all !important;
+  font-size: 1px;
   color: $body-background; // needs to match background color
-  line-height:1px;
-  max-height:0px;
-  max-width:0px;
-  opacity:0;
-  overflow:hidden;
+  line-height: 1px;
+  max-height: 0px;
+  max-width: 0px;
+  opacity: 0;
+  overflow: hidden;
 }
 
 

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -8,7 +8,6 @@
 
 .hide-for-large {
   display: none !important;
-  width: 0;
   mso-hide: all; // hide selected elements in Outlook 2007-2013
   overflow: hidden;
   max-height: 0;

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -8,26 +8,26 @@
 
 .hide-for-large {
   display: none !important;
-  width:0;
-  mso-hide:all; // hide selected elements in Outlook 2007-2013
-  overflow:hidden;
+  width: 0;
+  mso-hide: all; // hide selected elements in Outlook 2007-2013
+  overflow: hidden;
   max-height: 0;
   font-size: 0;
   width: 0;
-  line-height: 0; 
+  line-height: 0;
 
   @media only screen and (max-width: #{$global-breakpoint}) {
     display: block !important;
     width: auto !important;
     overflow: visible !important;
-    max-height: none !important; 
+    max-height: none !important;
     font-size: inherit !important;
     line-height: inherit !important;
   }
 }
 
 table.body table.container .hide-for-large * {
-  mso-hide:all; // hide selected elements in Outlook 2007-2013
+  mso-hide: all; // hide selected elements in Outlook 2007-2013
 }
 
 table.body table.container .hide-for-large,
@@ -48,9 +48,9 @@ table.body table.container .callout-inner.hide-for-large {
 table.body table.container .show-for-large {
   @media only screen and (max-width: #{$global-breakpoint}) {
     display: none !important;
-    width:0;
-    mso-hide:all; // hide selected elements in Outlook 2007-2013
-    overflow:hidden;
+    width: 0;
+    mso-hide: all; // hide selected elements in Outlook 2007-2013
+    overflow: hidden;
   }
 }
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -42,7 +42,7 @@ table {
     width: 100%;
     position: relative;
   }
-  
+
   &.spacer {
     width: 100%;
     td {

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -12,7 +12,6 @@
 //   7. Menu
 //   8. Thumbnail
 
-
 // 1. Global
 // ---------
 
@@ -94,16 +93,16 @@ $stat-font-size: 40px;
 // ---------
 
 $button-padding: (
-  tiny: 4px 8px 4px 8px,
-  small: 5px 10px 5px 10px,
-  default: 8px 16px 8px 16px,
-  large: 10px 20px 10px 20px,
+        tiny: 4px 8px 4px 8px,
+        small: 5px 10px 5px 10px,
+        default: 8px 16px 8px 16px,
+        large: 10px 20px 10px 20px,
 );
 $button-font-size: (
-  tiny: 10px,
-  small: 12px,
-  default: 16px,
-  large: 20px,
+        tiny: 10px,
+        small: 12px,
+        default: 16px,
+        large: 20px,
 );
 $button-color: $white;
 $button-color-alt: $medium-gray;


### PR DESCRIPTION
Started of with the addition to `.text-center` scss definition, as `TH` has not been considered there.

For maintainability purpose, I've refactored the way of these class declarations. I mean, with the previous approach, `table.text-left`, `table.text-right`, `td.text-left` and `td.text-right` were not even defined. My approach is to rule them all.

I've formatted the code, so it's clean, removed few blank lines, added spaces where necessary and removed the duplication of an attribute.

Hope that's fine.

Got confused with the contributing guide, so I've followed the one below:
https://github.com/zurb/foundation-emails/blob/develop/CONTRIBUTING.md#submitting-pull-requests
