### PR TITLE
fix incorrect info about custom data and fix prototype link

### DIFF
--- a/docs/pages/panini.md
+++ b/docs/pages/panini.md
@@ -12,7 +12,7 @@ If you've ever created a static site, maybe you had five pages that all shared t
 
 Panini is a flat file compiler that uses the concepts of templates, pages, and partials&mdash;powered by the [Handlebars](http://handlebarsjs.com/) templating language&mdash;to streamline the process of creating static prototypes.
 
-Our [prototyping template](starter-projects.html) uses Panini, along with a host of other tools for processing Sass and images, to make creating optimized templates easy. It's already been configured to utilize all of the features below, but if you want to learn the specifics of how to configure the library, head over to the [Panini GitHub page](https://github.com/zurb/panini).
+Our [prototyping template](https://github.com/zurb/foundation-emails-template) uses Panini, along with a host of other tools for processing Sass and images, to make creating optimized templates easy. It's already been configured to utilize most of the features below, but if you want to learn the specifics of how to configure the library, head over to the [Panini GitHub page](https://github.com/zurb/panini).
 
 ---
 
@@ -195,6 +195,8 @@ Then in your projects call your custom `{{#bold}}` helper
 Custom data can be added to your pages. This data can then be inserted into your HTML through Handlebars. There are two ways to add data to a project.
 
 To add variables to a specific page only, add it at the top of the page's HTML as a [Front Matter](http://jekyllrb.com/docs/frontmatter/) block. Let's say the below content is inside `src/pages/index.html`.
+
+**Before you can use custom data, be sure your Panini configuration has the `data: 'src/data'` path configured.**
 
 ```html
 ---


### PR DESCRIPTION
Either the source files that have panini preconfigured need to be updated to add the `data: 'src/data'` path or the documentation should reflect the requirement. 

Also the prototyping link was dead. I'm not sure if this is the correct new link but I've added it for now.
