### PR TITLE
Update gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Run `npm run build` to do a full email inlining process.
   @import "foundation-emails";
   ```
 
+Adding Inky's templating capabilities to Rails is easy thanks to the [**inky-rb**](https://github.com/zurb/inky-rb) gem, which bundles `foundation_emails` by default.
+
 ## Documentation
 
 **Check out our [Migration Guide](https://github.com/zurb/foundation-emails/blob/master/migration.md) for upgrading an existing template or for more in-depth code examples.**

--- a/gem/lib/foundation_emails/version.rb
+++ b/gem/lib/foundation_emails/version.rb
@@ -1,3 +1,3 @@
 module FoundationEmails
-  VERSION = "2.1.0.1"
+  VERSION = "2.2.0.0"
 end


### PR DESCRIPTION
- Bring gem version up to 2.2.0.0, prep it for release to Rubygems.
- Update to README to include info on inky-rb gem.
