### PR TITLE
Fix hide-for-large in Gmail, Yahoo and Outlook 2016

### DIFF
--- a/docs/pages/visibility.md
+++ b/docs/pages/visibility.md
@@ -16,18 +16,18 @@ Due to Outlook's lack of support for certain CSS properties, the Foundation for 
   <p>If you're using a visibility class on an image, be sure to apply it to the parent element, not to the image itself.</p>
 </div>
 
-**To show content only on mobile clients,** add the class `.hide-for-large` to the element.
+**To show content only on mobile clients,** add the class `.hide-for-large` to a div wrapping the element that needs to be hidden.
 
 **To show content only on desktop clients,** add the class `.show-for-large` to the element.
 
 ```inky_example
-<callout class="hide-for-large primary">
-  <p>This callout will only appear on small screens.</p>
-</callout>
+<div class="hide-for-large">
+  <callout class="primary">
+    <p>This callout will only appear on small screens.</p>
+  </callout>
+</div>
 
 <callout class="show-for-large alert">
   <p>This callout will only appear on large screens.</p>
 </callout>
 ```
-
-*note - `.hide-for-large` is not supported on Gmail and Yahoo email clients.*

--- a/docs/pages/visibility.md
+++ b/docs/pages/visibility.md
@@ -10,7 +10,7 @@ Visibility classes allow you to control what content appears on what screen size
 
 Foundation for Emails has two breakpoints: *small*, which is any email client under 596 pixels wide, and *large*, any client over 596 pixels. This means small generally correlates to mobile clients, and large correlates to desktop clients.
 
-Due to Outlook's lack of support for certain CSS properties, the Foundation for Emails visibility classes should be used in conjunction with conditional comments to ensure that the content is properly hidden (or shown) in Outlook 2007, 2010 and 2013.
+Due to Outlook's lack of support for certain CSS properties, the Foundation for Emails visibility classes should be used in conjunction with conditional comments to ensure that the content is properly hidden (or shown) in Outlook 2007, 2010, 2013 and 2016. For instance, in order to hide an element in MS Outlook as well as in e-mail forwarded from MS Outlook, make sure to wrap that element with `<!--[if !mso]><!-->` and `<!--<![endif]-->` conditional formatting.
 
 <div class="primary callout">
   <p>If you're using a visibility class on an image, be sure to apply it to the parent element, not to the image itself.</p>
@@ -21,11 +21,13 @@ Due to Outlook's lack of support for certain CSS properties, the Foundation for 
 **To show content only on desktop clients,** add the class `.show-for-large` to the element.
 
 ```inky_example
+<!--[if !mso]><!-->
 <div class="hide-for-large">
   <callout class="primary">
     <p>This callout will only appear on small screens.</p>
   </callout>
 </div>
+<!--<![endif]-->
 
 <callout class="show-for-large alert">
   <p>This callout will only appear on large screens.</p>

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -7,7 +7,7 @@
 ////
 
 .hide-for-large {
-  display: none !important;
+  display: none;
   mso-hide: all; // hide selected elements in Outlook 2007-2013
   overflow: hidden;
   max-height: 0;


### PR DESCRIPTION
Simply put in order to hide an element on large screens (where media queries are supported) and in email clients that don't support media queries (like Gmail, Gmail app and desktop version of Outlook) that element should have a wrapping `<div>` container (Yes! You read it right, a `<div>`, I know it may be surprising but that is what does the trick) with an inline style like: `style="display: none"` and a media query overwrite:

```
<style>
@media only screen and (max-width:596px){
  .hide-for-large { 
    display: block !important;
  }
}
</style>
```

...not to mention that both places should have all the other properties that various clients recognize (like `mso-hide`, `max-height`, etc) that do the trick of hiding/revealing an element. Didn't include them here for the sake of simplicity.

Current implementation of `.hide-for-large` is good enough except for having an `!important` which hides element even on small screens as it's getting written into the inline style of element and inline !important beats anything else so it's impossible to overwrite it in media query.

When !important is removed everything works just fine.

I've tested that on so many clients and devices I lost count already. But please back my tests with yours before merging. I'd love to know how it works out for you. Thanks.
