### PR TITLE
Update README's gem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Run `npm run build` to do a full email inlining process.
   bundle install
   ```
 
-3. Import Foundation for Emails in your `application.scss`:
+3. Import Foundation for Emails in your emails' stylesheet(s):
 
   ```scss
+  // app/assets/stylesheets/your_emails_stylesheet.scss
+
   @import "foundation-emails";
   ```
 

--- a/gem/README.md
+++ b/gem/README.md
@@ -20,11 +20,13 @@ Foundation for Emails (previously known as Ink) is a framework for creating resp
   bundle install
   ```
 
-3. Import Foundation for Emails in your `application.scss`:
+3. Import Foundation for Emails in your emails' stylesheet(s):
 
-  ```scss
-  @import "foundation-emails";
-  ```
+```scss
+// app/assets/stylesheets/your_emails_stylesheet.scss
+
+@import "foundation-emails";
+```
 
 ## License
 


### PR DESCRIPTION
Fix for README's gem installation instructions, clarifying that the foundation-emails assets should be included in their own dedicated manifest file, separate from `application.scss`.
