### PR TITLE
Set maxLineLength option to 800 for htmlmin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -216,7 +216,7 @@ function inliner(css) {
     .pipe($.htmlmin, {
       collapseWhitespace: false,
       minifyCSS: false,
-      maxLineLength: 800
+      maxLineLength: 78
     });
 
   return pipe();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -215,7 +215,8 @@ function inliner(css) {
     .pipe($.injectString.replace, '<!-- <style> -->', '<style>'+mqCss+'</style>')
     .pipe($.htmlmin, {
       collapseWhitespace: false,
-      minifyCSS: false
+      minifyCSS: false,
+      maxLineLength: 800
     });
 
   return pipe();

--- a/scss/components/_media-query.scss
+++ b/scss/components/_media-query.scss
@@ -34,8 +34,8 @@
     // Nested columns won't double the padding
     .column,
     .columns {
-      padding-left: 0 !important;
-      padding-right: 0 !important;
+      //padding-left: 0 !important;
+      //padding-right: 0 !important;
     }
   }
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -71,8 +71,8 @@ th.column {
   // Prevents Nested columns from double the padding
   .column,
   .columns {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
+    //padding-left: 0 !important;
+    //padding-right: 0 !important;
 
     center {
       min-width: none !important;


### PR DESCRIPTION
Gmail automatically adds linebreaks if lines are too long and doesn't care about code being split by newlines at invalid HTML split-points. This PR prevents this to happen.
