### PR TITLE
Fix text alignment in long buttons when text breaks over more than one line

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -75,6 +75,7 @@ table.button {
         font-weight: $button-font-weight;
         color: $button-color;
         text-decoration: none;
+        text-align: left;
         display: inline-block;
         padding: map-get($button-padding, default);
         border: 0 solid $button-background;


### PR DESCRIPTION
If a button contains a large amount of text (enough that screen width forces it to split to 2 lines) the text is left aligned rather than centered.

Adding `text-align:left` to the anchor element causes this to center in the button.
