### PR TITLE
Fix gutter between columns on nested grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![downloads badge](http://img.shields.io/npm/dm/foundation-emails.svg)](https://www.npmjs.org/package/foundation-emails)
 [![Gem Version](https://badge.fury.io/rb/foundation_emails.svg)](https://badge.fury.io/rb/foundation_emails)
 [![downloads badge](http://img.shields.io/npm/l/foundation-emails.svg)](https://www.npmjs.org/package/foundation-emails)
+[![CDNJS](https://img.shields.io/cdnjs/v/foundation-emails.svg)](https://cdnjs.com/libraries/foundation-emails)
 
 
 Foundation for Emails (previously known as Ink) is a framework for creating responsive HTML emails that work in any email client &mdash; even Outlook. Our HTML/CSS components have been tested across every major email client to ensure consistency. And with the [Inky](https://github.com/zurb/inky) templating language, writing HTML emails is now even easier.

--- a/docs/pages/sass-guide.md
+++ b/docs/pages/sass-guide.md
@@ -168,7 +168,7 @@ Now that you have an inlined email, you'll need to test it in real email clients
 
 The most popular tool for testing emails is [Litmus](https://litmus.com/). All you have to do is paste in the HTML of an email, and you get a live preview in any email client you want.
 
-It's up to you to choose what email clients are important to test in, but you can [see our compatability list](compatibility.html) for recommendations.
+It's up to you to choose what email clients are important to test in, but you can [see our compatibility list](compatibility.html) for recommendations.
 
 ---
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -69,11 +69,17 @@ th.column {
   padding-bottom: $column-padding-bottom;
 
   // Prevents Nested columns from double the padding
+  .column.first,
+  .columns.first {
+    padding-left: 0 !important;
+  }
+  .column.last,
+  .columns.last {
+    padding-right: 0 !important;
+  }
+
   .column,
   .columns {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-
     center {
       min-width: none !important;
     }


### PR DESCRIPTION
On nested grids, only the outside gutters should be removed, namely the gutter to the left of the first column and the gutter to the right of the last column. The gutter between the columns should be present on nested columns, unless the grid is collapsed.
