### PR TITLE
Let buttons expand in Outlook

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -145,7 +145,7 @@ table.button.large {
 
 table.button.expand,
 table.button.expanded {
-  width: 100% !important;
+  width: 100%;
 
   table {
     width: 100%;


### PR DESCRIPTION
!important styles are ignored by Outlook when they are inlined. There are no other rules that would override the width of the expanded buttons, so it is not necessary to have it declared as !important. Removing !important means that the style will be inlined as style="width: 100%" instead of style="width: 100% !important". The latter is ignored by Outlook, while the first one works and makes the button expand. Ref: https://www.campaignmonitor.com/blog/email-marketing/2010/05/outlook-2007-and-the-inline-important-declaration/