### PR TITLE
Do not use shorthand notation for padding

### DIFF
--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -77,7 +77,10 @@ td {
 }
 
 table, tr, td {
-  padding: 0;
+  padding-top: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+  padding-left: 0;
   vertical-align: top;
   text-align: left;
 }

--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -165,7 +165,10 @@ a {
   color: $global-font-color;
   font-family: $body-font-family;
   font-weight: $global-font-weight;
-  padding: 0;
+  padding-top: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+  padding-left: 0;
   margin: 0;
   Margin: 0;
   text-align: left;


### PR DESCRIPTION
When inlining css styles, "padding: 0" can enter in conflict with specific padding like "padding-left: 8px" because inlined styles order can be changed by email clients (eg: gmail).
To avoid any potential conflict, not using shorthand notation ensure that padding is not overwritten by padding:0 rules.