### PR TITLE
Do not set pixel-width for <center> tags

### DIFF
--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -56,7 +56,6 @@ img {
 
 center {
   width: 100%;
-  min-width: $global-width;
 }
 
 a img {

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -141,11 +141,6 @@ th.column {
     }
   }
 
-  td.large-#{$i} center,
-  th.large-#{$i} center {
-    min-width: -zf-grid-calc-px($i, $grid-column-count, $global-width) - ($global-gutter * 2);
-  }
-
   .body .columns td.large-#{$i},
   .body .column td.large-#{$i},
   .body .columns th.large-#{$i},

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -73,10 +73,6 @@ th.column {
   .columns {
     padding-left: 0 !important;
     padding-right: 0 !important;
-
-    center {
-      min-width: none !important;
-    }
   }
 }
 


### PR DESCRIPTION
Setting min-width to a pixel-value on the `<center>` tag breaks the layout if the `<center>`-tag is inside a nested grid. It should be enough to have width: 100%.

Consider this example:

    <container>
       <row>
          <columns large="10">
             <row>
                <columns large="6">
                   <center>Some centered content</center>
                </columns>
                <columns large="6">
                   <center>Some centered content</center>
                </columns>
             </row>
          </columns>
          <columns large="2">
             Some side-content
          </columns>
       </row>
    </container>

Basing the width of the `<center>` tags on the size of the containing column doesn't work, since they are within a column with size 6 inside a column with size 10.