### PR TITLE
Fixed broken CSS Support Chart link

### DIFF
--- a/docs/pages/tips-tricks.md
+++ b/docs/pages/tips-tricks.md
@@ -113,7 +113,7 @@ Speaking of CSS, you should only set classes and IDs on tables or `<td>` tags, n
 Support of CSS properties varies greatly between email clients. You're best off sticking with the basics and not getting too fancy.
 
 This CSS compatibility chart will really save you some pain when writing CSS:
-[CSS Support Chart](https://www.campaignmonitor.com/css/b/)
+[CSS Support Chart](https://www.campaignmonitor.com/css/)
 
 <img src="assets/img/campaign-monitor-css-guide.jpg" alt="">
 


### PR DESCRIPTION
The link provided for CSS Support Chart has been broken so i replaced it with the correct one.