### PR TITLE
Anchor margins

### DIFF
--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -160,8 +160,7 @@ h5,
 h6,
 p,
 td,
-th,
-a {
+th {
   color: $global-font-color;
   font-family: $body-font-family;
   font-weight: $global-font-weight;
@@ -247,6 +246,11 @@ small {
 a {
   color: $anchor-color;
   text-decoration: $anchor-text-decoration;
+  font-family: $body-font-family;
+  font-weight: $global-font-weight;
+  padding: 0;
+  text-align: left;
+  line-height: $global-line-height;
 
   &:hover {
     color: $anchor-color-hover;

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -69,11 +69,17 @@ th.column {
   padding-bottom: $column-padding-bottom;
 
   // Prevents Nested columns from double the padding
+  .column.first,
+  .columns.first {
+    padding-left: 0 !important;
+  }
+  .column.last,
+  .columns.last {
+    padding-right: 0 !important;
+  }
+
   .column,
   .columns {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-
     center {
       min-width: none !important;
     }

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -69,17 +69,11 @@ th.column {
   padding-bottom: $column-padding-bottom;
 
   // Prevents Nested columns from double the padding
-  .column.first,
-  .columns.first {
-    padding-left: 0 !important;
-  }
-  .column.last,
-  .columns.last {
-    padding-right: 0 !important;
-  }
-
   .column,
   .columns {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+
     center {
       min-width: none !important;
     }


### PR DESCRIPTION
There is a bug in Outlook 2016 (and possibly other versions) that leads to a `p` element losing its `margin` if there is an `a` element inside the `p`, and the `a` element has css `margin` specified. `a` elements are by default inline and without margins, so it shouldn't cause any problems to solved the issue by just not specifying `margin` for `a` elements.

To sum up: Outlook behaves like this:

    <p style="margin: 0 0 10px 0; Margin: 0 0 10px 0;">This will have a <a href="/foo">bottom margin</a>.</p>
    <p style="margin: 0 0 10px 0; Margin: 0 0 10px 0;">This will not have a <a href="/foo" style="margin: 0; Margin: 0;">bottom margin</a>, since margin is specified for the anchor element.</p>

The issue is solved by not specifying `margin` for `a` elements by default.