### PR TITLE
Width of centered menus

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -63,7 +63,7 @@ table.menu.text-center a {
 
 //Centers the menus!
 .menu[align="center"] {
-  width: auto !important;
+  width: auto;
 }
 
 // Remove outside padding so that the menu aligns with other elements on the page


### PR DESCRIPTION
`!important` styles are ignored by Outlook when they are inlined. The rule setting the width of centered menus (`.menu[align="center"]`) has higher specificity than the other rule setting the menu width (`table.menu`), so it is not necessary to have `width` declared as `!important`. Removing `!important` means that the style will be inlined as `style="width: 100%"` instead of `style="width: 100% !important"`. The latter is ignored by Outlook, while the first one works. Ref: https://www.campaignmonitor.com/blog/email-marketing/2010/05/outlook-2007-and-the-inline-important-declaration/