### PR TITLE
Normalize the th element

### DIFF
--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -31,6 +31,7 @@ body {
   span,
   font,
   td,
+  th,
   div {
     line-height: 100%;
   }
@@ -68,7 +69,7 @@ table {
   border-collapse: collapse;
 }
 
-td {
+td, th {
   word-wrap: break-word;
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
@@ -76,7 +77,7 @@ td {
   border-collapse: collapse !important;
 }
 
-table, tr, td {
+table, tr, td, th {
   padding-top: 0;
   padding-right: 0;
   padding-bottom: 0;


### PR DESCRIPTION
Normalize the `th` element. I have specifically observed that `th` elements sometimes show content vertically aligned in the middle. `th` elements are used for all columns, so they should be normalized to be vertically aligned to the top.