### PR TITLE
Fix button width in Outlook's "View in Browser"

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -95,6 +95,10 @@ table.button {
   }
 }
 
+table.button:not(.expand):not(.expanded) table {
+  width: auto;
+}
+
 table.button:hover table tr td a,
 table.button:active table tr td a,
 table.button table tr td a:visited,


### PR DESCRIPTION
The grid rule

    //makes sure nested tables are 100% width
    td.columns,
    td.column,
    th.columns,
    th.column {
      table:not(.button) {
        width: 100%;
      }
    }

sets the inner table of buttons to `width: 100%`. This breaks the layout when reading the email in IE by using the "View in Browser" feature in Outlook. The wide inner table causes the buttons to break over multiple lines. This fix sets the inner table to `width: auto` for non-expanded buttons.