### PR TITLE
Fix button margin and padding

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -58,8 +58,10 @@ $button-rounded: $global-rounded !default;
 
 table.button {
   width: auto;
-  margin: $button-margin;
-  Margin: $button-margin;
+  
+  td {
+     padding: $button-margin;
+  }
 
   table {
 
@@ -68,6 +70,7 @@ table.button {
       color: $button-color;
       background: $button-background;
       border: $button-border;
+      padding: 0;
 
       a {
         font-family: $body-font-family;

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -112,12 +112,8 @@ table.button.large table tr td a:visited {
 
 table.button.tiny {
   table {
-    td,
     a {
       padding: map-get($button-padding, tiny);
-    }
-
-    a {
       font-size: map-get($button-font-size, tiny);
       font-weight: normal;
     }
@@ -126,7 +122,6 @@ table.button.tiny {
 
 table.button.small {
   table {
-    td,
     a {
       padding: map-get($button-padding, small);
       font-size: map-get($button-font-size, small);


### PR DESCRIPTION
Outlook does not show margin on table-elements. Instead, the button margin must be applied as padding on the td-element of the outer table. To prevent the padding from being added to the td-element of the inner table, the padding is set to 0 for this element. Padding should not be applied to the td-element of the inner table for tiny and small buttons. This has been fixed.