### PR TITLE
Typo fix (raidus -> radius)

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -78,7 +78,7 @@ $global-padding: 16px !default;
 /// @type Number
 $global-margin: 16px !default;
 
-/// Global raidus of radius-corners.
+/// Global radius of radius-corners.
 /// @type Number
 $global-radius: 3px !default;
 


### PR DESCRIPTION
Changing "raidus" to "radius"

This typo was propagating into the documentation as well!