### PR TITLE
Various <hr> fixes

### DIFF
--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -124,7 +124,7 @@ $hr-border: 1px solid $black !default;
 
 /// Default margin for a divider.
 /// @type Number | List
-$hr-margin: 20px auto !default;
+$hr-margin: 20px !default;
 
 /// Text decoration for anchors.
 /// @type Keyword
@@ -308,20 +308,33 @@ pre {
 }
 
 // Horizontal rule
-table.hr {
+table.hr,
+table.h-line {
   width: 100%;
 
   th {
-    height: 0;
-    max-width: $hr-width;
-    border-top: 0;
-    border-right: 0;
-    border-bottom: $hr-border;
-    border-left: 0;
-    margin: $hr-margin;
-    Margin: $hr-margin;
-    clear: both;
+    padding-bottom: $hr-margin;
+    text-align: center;
   }
+
+    table {
+      width: 100%;
+      max-width: $hr-width;
+      margin: 0 auto;
+    }
+
+    td {
+      height: 0;
+      width: $hr-width;
+      padding-top: $hr-margin;
+      font-size: 0;
+      line-height: 0;
+      border-top: 0;
+      border-right: 0;
+      border-bottom: $hr-border;
+      border-left: 0;
+      clear: both;
+    }
 }
 
 // Use to style a large number to display a statistic

--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -126,6 +126,10 @@ $hr-border: 1px solid $black !default;
 /// @type Number | List
 $hr-margin: 20px !default;
 
+/// Default alignment for a divider.
+/// @type String
+$hr-align: center !default;
+
 /// Text decoration for anchors.
 /// @type Keyword
 $anchor-text-decoration: none !default;
@@ -153,6 +157,52 @@ $stat-font-size: 40px !default;
 /// Removing the iOS telephone and address styling
 /// @type Boolean
 $remove-ios-blue: true !default;
+
+/// Create a divider/horizontal rule.
+/// @param {String} $align  - Left, center, or right
+/// @param {String} $width  - Width of divider
+/// @param {String} $border - Shorthand border style for divider
+/// @param {String} $margin - Margin above and below divider
+@mixin h-line($align: $hr-align, $width: $hr-width, $border: $hr-border, $margin: nth($hr-margin, 1)) {
+  @at-root {
+    td.columns & table,
+    td.column  & table,
+    th.columns & table,
+    th.column  & table {
+      width: auto;
+    }
+  }
+
+  th {
+    padding-bottom: $margin;
+    @if $align == 'left' {
+      text-align: left;
+    } @elseif $align == 'right' {
+      text-align: right;
+    } @else {
+      text-align: center;
+    }
+  }
+
+    table {
+      display: inline-block;
+      margin: 0;
+      Margin: 0;
+    }
+
+      td {
+        width: $width;
+        height: 0;
+        padding-top: $margin;
+        clear: both;
+        border-top: 0;
+        border-right: 0;
+        border-bottom: $border;
+        border-left: 0;
+        font-size: 0;
+        line-height: 0;
+      }
+}
 
 body,
 table.body,
@@ -310,31 +360,7 @@ pre {
 // Horizontal rule
 table.hr,
 table.h-line {
-  width: 100%;
-
-  th {
-    padding-bottom: $hr-margin;
-    text-align: center;
-  }
-
-    table {
-      width: 100%;
-      max-width: $hr-width;
-      margin: 0 auto;
-    }
-
-    td {
-      height: 0;
-      width: $hr-width;
-      padding-top: $hr-margin;
-      font-size: 0;
-      line-height: 0;
-      border-top: 0;
-      border-right: 0;
-      border-bottom: $hr-border;
-      border-left: 0;
-      clear: both;
-    }
+  @include h-line($hr-align, $hr-width, $hr-border, $hr-margin);
 }
 
 // Use to style a large number to display a statistic


### PR DESCRIPTION
Fix margin around `<hr>`s (#647)
Make `<hr>`s 0-height (#648)
Make `<hr>`s obey `$hr-width` (#678)
Make `<hr`>s obey `$hr-margin` in Outlook 2007/10/13 (#682)
Add `h-line` mixin to create different horizontal rules/dividers

The code required to render these horizontal rules (and this differs from the proposed Inky `<h-line>` code, so that may need to be updated as well):

```html
<table class="hr">
  <tr>
    <th>
      <table><tr><td>&nbsp;</td></tr></table>
    </th>
  </tr>
</table>
```

Also, in order for this to work, `$hr-margin` will need to be a single value rather than something like `20px auto`; Outlook and others don't obey `margin`on tables, so this is instead handled with `padding-bottom` (on the outer `th`) and `padding-top` (on the inner `td` with `border-bottom`).

I've also added support for the `table.h-line` selector, which looks like it will be used in an upcoming Inky release when `<h-line>` is implemented. (zurb/inky#46)

Also addresses #496 and #554, for which some of my Issues above are potential duplicates.