### PR TITLE
add option to specify server port at runtime

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,7 +111,8 @@ gulp.task('lint', function() {
 // Creates a BrowserSync server
 gulp.task('server', ['build'], function() {
   browser.init({
-    server: './_build'
+    server: './_build',
+    port: yargs.argv.port || 3001
   });
 });
 


### PR DESCRIPTION
Add the option to specify browser-sync server port at runtime with the following npm-standard syntax: 

```npm start -- --port={PORT}```

Change leverages functionality already present in browser-sync, so all we are doing here is parsing the args to see if a `port` argument exists and passing it to browser-sync instead of the default port.