### PR TITLE
Body spacing fix

### DIFF
--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -29,7 +29,7 @@ $container-radius: 0 !default;
 table {
   &.body {
     background: $body-background;
-    height: 100%;
+    height: auto;
     width: 100%;
   }
 


### PR DESCRIPTION
`height: 100%;` on table.body caused huge vertical spacing on outlook web and the GOOD mobile app