### PR TITLE
Add text size classes

### DIFF
--- a/docs/pages/typography.md
+++ b/docs/pages/typography.md
@@ -54,6 +54,26 @@ By inserting a `<small>` element into a header Foundation will scale the header 
 
 ---
 
+## Text Sizes
+
+You can change the size of text in paragraphs with `.text-` classes. These classes will apply to the large breakpoint as well as the small.
+
+```inky_example
+<container>
+  <row>
+    <columns>
+      <p class="text-xs">Extra small</p>
+      <p class="text-sm">Small</p>
+      <p class="text-lg">Large</p>
+      <p class="text-xl">Extra large</p>
+      <p class="text-xxl">Extra extra large</p>
+    </columns>
+  </row>
+</container>
+```
+
+---
+
 ## Links
 
 Links are very standard, and the color is preset to the Foundation primary color. [Learn more about Foundation's global colors](global.html).

--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -82,6 +82,10 @@ $small-font-size: 80% !default;
 /// @type Color
 $small-font-color: $medium-gray !default;
 
+/// Default scaling coefficient for text sizes.
+/// @type Number
+$font-scale: 1.2 !default;
+
 /// Font size of lead paragraphs.
 /// @type Number
 $lead-font-size: $global-font-size * 1.25 !default;
@@ -237,6 +241,26 @@ p {
     line-height: $subheader-lineheight;
     color: $subheader-color;
   }
+}
+
+.text-xs {
+  font-size: $global-font-size / ($font-scale * $font-scale);
+}
+
+.text-sm {
+  font-size: $global-font-size / $font-scale;
+}
+
+.text-lg {
+  font-size: $global-font-size * $font-scale;
+}
+
+.text-xl {
+  font-size: $global-font-size * ($font-scale * $font-scale);
+}
+
+.text-xxl {
+  font-size: $global-font-size * ($font-scale * $font-scale * $font-scale);
 }
 
 small {


### PR DESCRIPTION
Would be nice to have a few default text sizes. Sample:

![screen shot 2017-04-05 at 3 48 35 pm](https://cloud.githubusercontent.com/assets/643417/24723947/60879bda-1a17-11e7-8a43-e6e0c3780378.png)
