### PR TITLE
Only collapse the outside gutters

### DIFF
--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -71,8 +71,8 @@ th.column {
   // Prevents Nested columns from double the padding
   .column,
   .columns {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
+    &.first{padding-left:0 !important;}
+    &.last {padding-right:0 !important;}
 
     center {
       min-width: none !important;


### PR DESCRIPTION
Nested Columns should only collapse the outside padding. not the gutters on the inside. 