### PR TITLE
Collapse Classes

### DIFF
--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -95,6 +95,8 @@ The `.expander` prevents a rendering bug in Outlook that sometimes keeps the col
 
 Collapsing a row removes the gutters from every column, which is the spacing between them. Add the class `.collapse` to a row to enable this.
 
+There are more utility classes that you can use to isolate and collapse portions of your layouts: `.collapse-top` `.collapse-bottom` `.collapse-left` `.collapse-right` `.collapse-border` `.collapse-gutter`
+
 ```inky_example
 <row class="collapse">
   <columns large="6"><img src="http://placehold.it/300x150/777777/&text=These columns touch" alt=""></columns>

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -170,3 +170,24 @@ table.container.radius {
   border-radius: $container-radius;
   border-collapse: separate;
 }
+
+// Collapse Classes : collapse-gutter, collapse-bottom, collapse-top, collapse-border
+.collapse-gutter, .collapse-gutter>tbody>tr>.columns {
+    padding-left:0!important;
+    padding-right:0!important;
+}
+.collapse-bottom,
+.collapse-bottom>tbody>tr>.columns,
+.text.collapse-bottom th {
+    padding-bottom:0!important;
+    margin-bottom:0!important;
+    Margin-bottom:0!important;
+}
+.collapse-top {
+    padding-top:0!important;
+    margin-top:0!important;
+    Margin-top:0!important;
+}
+.collapse-border th {
+  border:none!important;
+}

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -184,10 +184,23 @@ table.container.radius {
     Margin-bottom:0!important;
 }
 .collapse-top {
+.collapse-top>tbody>tr>.columns,
+.text.collapse-top th {
     padding-top:0!important;
     margin-top:0!important;
     Margin-top:0!important;
 }
+.collapse-left {
+    padding-left:0!important;
+    margin-left:0!important;
+    Margin-left:0!important;
+}
+.collapse-right {
+    padding-right:0!important;
+    margin-right:0!important;
+    Margin-right:0!important;
+}
+.collapse-border,
 .collapse-border th {
   border:none!important;
 }


### PR DESCRIPTION
Helper classes to collapse things. These just make it useful to quickly remove the default margins added for things. 