### PR TITLE
Inherit h1-h6 size from $global-font-size variable

### DIFF
--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -44,27 +44,27 @@ $header-font-weight: $global-font-weight !default;
 
 /// Font size of `<h1>` elements.
 /// @type Number
-$h1-font-size: 34px !default;
+$h1-font-size: floor($global-font-size * 2.125) !default;
 
 /// Font size of `<h2>` elements.
 /// @type Number
-$h2-font-size: 30px !default;
+$h2-font-size: floor($global-font-size * 1.875) !default;
 
 /// Font size of `<h3>` elements.
 /// @type Number
-$h3-font-size: 28px !default;
+$h3-font-size: floor($global-font-size * 1.75) !default;
 
 /// Font size of `<h4>` elements.
 /// @type Number
-$h4-font-size: 24px !default;
+$h4-font-size: floor($global-font-size * 1.5) !default;
 
 /// Font size of `<h5>` elements.
 /// @type Number
-$h5-font-size: 20px !default;
+$h5-font-size: floor($global-font-size * 1.2) !default;
 
 /// Font size of `<h6>` elements.
 /// @type Number
-$h6-font-size: 18px !default;
+$h6-font-size: floor($global-font-size * 1.125) !default;
 
 /// Margin bottom of `<h1>` through `<h6>` elements.
 /// @type Number


### PR DESCRIPTION
Since a variable already exists for the global font size, it'd be nice to allow all typographic elements to scale proportionally from this one base property.

The Sass `floor` function ensures that only integers are used for output px units, since decimal units can cause issues in older clients.