### PR TITLE
Option for responsive gutters

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -62,6 +62,10 @@ $global-width-small: 95% !default;
 /// @type length
 $global-gutter: 16px !default;
 
+/// Gutter for grid elements on small screens.
+/// @type length
+$global-gutter-small: $global-gutter !default;
+
 /// Body background color.
 /// @type Length
 $body-background: $light-gray !default;

--- a/scss/components/_media-query.scss
+++ b/scss/components/_media-query.scss
@@ -28,8 +28,8 @@
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
-    padding-left: $global-gutter !important;
-    padding-right: $global-gutter !important;
+    padding-left: $global-gutter-small !important;
+    padding-right: $global-gutter-small !important;
 
     // Nested columns won't double the padding
     .column,

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -30,6 +30,7 @@ $pre-color: #ff6908;
 $global-width: 580px;
 $global-width-small: 95%;
 $global-gutter: 16px;
+$global-gutter-small: $global-gutter;
 $body-background: $light-gray;
 $container-background: $white;
 $global-padding: 16px;


### PR DESCRIPTION
Added `$global-gutter-small` var to settings and media-query to allow for
different gutter sizes on mobile and desktop.

Implementation of #764 