### PR TITLE
Fix primary callout border

### DIFF
--- a/scss/components/_callout.scss
+++ b/scss/components/_callout.scss
@@ -55,7 +55,7 @@ th.callout-inner {
 
   &.primary {
     background: scale-color($primary-color, $lightness: $callout-background-fade);
-    border: $callout-border-secondary;
+    border: $callout-border;
     color: $black;
   }
 


### PR DESCRIPTION
A callout with a class of primary should use the primary color for its border - not secondary.
