### PR TITLE
Remove :not selector since not XPath compatible

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -145,7 +145,7 @@ table.button.large {
 
 table.button.expand,
 table.button.expanded {
-  width: 100%;
+  width: 100%!important;
 
   table {
     width: 100%;

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -145,7 +145,7 @@ table.button.large {
 
 table.button.expand,
 table.button.expanded {
-  width: 100%!important;
+  width: 100%;
 
   table {
     width: 100%;

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -92,8 +92,12 @@ td.columns,
 td.column,
 th.columns,
 th.column {
-  table:not(.button) {
+  table {
     width: 100%;
+
+    &.button {
+      width:auto;
+    }
   }
 }
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -97,6 +97,10 @@ th.column {
 
     &.button {
       width:auto;
+
+      &.expanded{
+        width: 100%;
+      }
     }
   }
 }


### PR DESCRIPTION
I needed to build my own Inliner uses PHP. When using XPath standard to query selectors in the DOM, the `:not()` css pseudo element is not XPath compatible. Since this is only used once through out the entire framework (and the fix was easy) I thought that it would be nice to have the entire framework compatible. With this change, you can now inline via PHP. 