### PR TITLE
Remove box sizing vendor prefixes

### DIFF
--- a/scss/components/_media-query.scss
+++ b/scss/components/_media-query.scss
@@ -25,8 +25,6 @@
   table.body .columns,
   table.body .column {
     height: auto !important;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
     box-sizing: border-box;
     padding-left: $global-gutter !important;
     padding-right: $global-gutter !important;

--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -18,8 +18,6 @@ body {
   margin: 0;
   Margin: 0;
   padding: 0;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Its not used my email clients and all modern browsers support box-sizing anyways. 

By having it in there, it generates a bunch of validation errors when using email validators like on Email On Acid. It also adds unnecessary inline styles. 