### PR TITLE
Update Callout Styling

### DIFF
--- a/scss/components/_callout.scss
+++ b/scss/components/_callout.scss
@@ -68,18 +68,18 @@ th.callout-inner {
   &.success {
     background: scale-color($success-color, $lightness: $callout-background-fade);
     border: $callout-border-success;
-    color: $white;
+    color: $black;
   }
 
   &.warning {
     background: scale-color($warning-color, $lightness: $callout-background-fade);
     border: $callout-border-warning;
-    color: $white;
+    color: $black;
   }
 
   &.alert {
     background: scale-color($alert-color, $lightness: $callout-background-fade);
     border: $callout-border-alert;
-    color: $white;
+    color: $black;
   }
 }


### PR DESCRIPTION
See Issue #798 in main project: Callouts of classes success, warning and alert were having light text on light background.
This PR will change the text color for th.callout.success, th.callout.warning and th.callout.alert to black-ish to make sure content of a Callout, not being wrapped in a `<p>`-tag are still readable.
