### PR TITLE
Update _typography.scss

### DIFF
--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -228,6 +228,11 @@ th {
 p {
   margin-bottom: $paragraph-margin-bottom;
   Margin-bottom: $paragraph-margin-bottom;
+  
+  a {
+	  Margin: inherit; 
+	  margin: inherit;
+  }
 
   &.lead {
     font-size: $lead-font-size;


### PR DESCRIPTION
Fix issue with Outlook for Windows where adding a link within a paragraph will remove the paragraph bottom margin.

Before submitting a pull request, make sure it's targeting the right branch:

- For fixes to Ink 1.0, use `master`.
- For fixes to Foundation for Emails 2, use `v2.0`.

Happy coding! :)
