### PR TITLE
#815 - Over calculation of columns widths can cause different width columns

### DIFF
--- a/scss/util/_util.scss
+++ b/scss/util/_util.scss
@@ -18,5 +18,5 @@
 /// @param {number} $containerWidth - Width of the surrounding container, in pixels.
 /// @returns {number} A pixel width value.
 @function -zf-grid-calc-px($columnNumber, $totalColumns, $containerWidth) {
-  @return ($containerWidth / $totalColumns * $columnNumber - $global-gutter);
+  @return (($containerWidth - $global-gutter) / $totalColumns * $columnNumber - $global-gutter);
 }


### PR DESCRIPTION
Foundation seems to over-calculate the total of a row by $global-gutter, which leaves the client having to resizing the columns

Instead of
```
               container width
               ---------------
               No of columns
```

it should calculate

```
               container width - gutter width
               ------------------------------
                      No of columns
```

as there is an additional half gutter at each end of the row.

eg:
```
<row>
     <columns small="2">...</columns>
     <columns small="4">...</columns>
     <columns small="6">...</columns>
</row>
```

```
                     | half | half |      | half | half |
       |gutter|column|gutter|gutter|column|gutter|gutter|column|gutter|
before |  16  |80.66 |   8  |   8  |177.33|   8  |   8  |  274 |  16  | = 596
after  |  16  |  78  |   8  |   8  |  172 |   8  |   8  |  266 |  16  | = 580
```