### PR TITLE
Fix nested column padding

### DIFF
--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -69,11 +69,18 @@ th.column {
   padding-bottom: $column-padding-bottom;
 
   // Prevents Nested columns from double the padding
+  .column.first,
+  .columns.first, {
+    padding-left: 0 !important;
+  }
+
+  .column.last,
+  .columns.last {
+    padding-right: 0 !important;
+  }
+
   .column,
   .columns {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-
     center {
       min-width: none !important;
     }

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -211,3 +211,4 @@ table.container.radius {
 .collapse-border th {
   border:none!important;
 }
+


### PR DESCRIPTION
Instead of removing both the right and left padding from all nested columns, remove just the left padding from a nested .first column and the right padding from a nested .last column. This prevents the double padding on the sides while keeping the gutter between the columns.