### PR TITLE
remove font family form th and td and table

### DIFF
--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -165,9 +165,6 @@ h6,
 p,
 td,
 th {
-  color: $global-font-color;
-  font-family: $body-font-family;
-  font-weight: $global-font-weight;
   padding-top: 0;
   padding-right: 0;
   padding-bottom: 0;
@@ -176,6 +173,18 @@ th {
   Margin: 0;
   text-align: left;
   line-height: $global-line-height;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  color: $global-font-color;
+  font-family: $body-font-family;
+  font-weight: $global-font-weight;
 }
 
 h1,


### PR DESCRIPTION
Font family on gmail th and td causes incorrect font to render in gmail

Before submitting a pull request, make sure it's targeting the right branch:

- For fixes to Ink 1.0, use `master`.
- For fixes to Foundation for Emails 2, use `v2.0`.

Happy coding! :)
