### PR TITLE
Add .small class into typography

### DIFF
--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -245,7 +245,8 @@ p {
   }
 }
 
-small {
+small
+.small {
   font-size: $small-font-size;
   color: $small-font-color;
 }


### PR DESCRIPTION
The same way as we can use the `<p class="lead">foo</p>` it makes sense to have `<p class="small">bar</p>` instead of `<p><small>bar</small></a>`