### PR TITLE
Spelling mistake under Inlining CSS heading

### DIFF
--- a/docs/pages/tips-tricks.md
+++ b/docs/pages/tips-tricks.md
@@ -123,7 +123,7 @@ For some things you can do and work-arounds, see the <a href="#progressive-enhan
 
 #### Inlining CSS
 
-Gmail strips the `<head>` (and, consequently, `<style>`) tags from your email. Therefor your email's CSS needs to be inlined. You know, like old school CSS:
+Gmail strips the `<head>` (and, consequently, `<style>`) tags from your email. Therefore your email's CSS needs to be inlined. You know, like old school CSS:
 
 ```html
 <table class="menu" style="padding:0;text-align:center;vertical-align:top;width:auto">


### PR DESCRIPTION
"Therefore" was spelled "Therefor"

Before submitting a pull request, make sure it's targeting the right branch:

- For fixes to Ink 1.0, use `master`.
- For fixes to Foundation for Emails 2, use `v2.0`.

Happy coding! :)
