### PR TITLE
Replace placeholder image urls

### DIFF
--- a/docs/pages/alignment.md
+++ b/docs/pages/alignment.md
@@ -75,7 +75,7 @@ Just wrap the `<center>` around an image you’ll be good to go. Inky will handl
   <row>
     <columns>
       <center>
-        <img src="https://placehold.it/200?text=center" alt="image of clever meme that made me chuckle">
+        <img src="https://via.placeholder.com/200?text=center" alt="image of clever meme that made me chuckle">
       </center>
     </columns>
   </row>
@@ -98,7 +98,7 @@ If you need to center an image only on mobile clients, you can apply the `.small
 <container>
   <row>
     <columns small="12" large="3" class="large-offset-1">
-      <img class="small-float-center" src="https://placehold.it/200?text=small-center" alt="please don't forget me">
+      <img class="small-float-center" src="https://via.placeholder.com/200?text=small-center" alt="please don't forget me">
     </columns>
     <columns small="12" large="8">
       <h4 class="small-text-center">What is the deal?</h4>
@@ -118,9 +118,9 @@ You can also align images to the left or the right.
 <container>
   <row>
     <columns>
-      <img class="float-left" src="https://placehold.it/200?text=left" alt="">
-      <img class="float-center" src="https://placehold.it/200?text=center" alt="">
-      <img class="float-right" src="https://placehold.it/200?text=right" alt="">
+      <img class="float-left" src="https://via.placeholder.com/200?text=left" alt="">
+      <img class="float-center" src="https://via.placeholder.com/200?text=center" alt="">
+      <img class="float-right" src="https://via.placeholder.com/200?text=right" alt="">
     </columns>
   </row>
 </container>
@@ -198,7 +198,7 @@ You can vertically align your content within columns by using `valign` attribute
 ```inky_example
 <row>
   <columns large="3" valign="top">
-    <img class="float-right" src="https://placehold.it/50" alt="">
+    <img class="float-right" src="https://via.placeholder.com/50" alt="">
   </columns>
   <columns large="3" valign="bottom">
     <h4>Bottom</h4>
@@ -208,7 +208,7 @@ You can vertically align your content within columns by using `valign` attribute
     <p style="margin-bottom: 0;" class="text-right subheader">SUBHEADLINE</p>
   </columns>
   <columns large="3" valign="middle">
-    <img class="small-float-center" src="https://placehold.it/250" alt="">
+    <img class="small-float-center" src="https://via.placeholder.com/250" alt="">
   </columns>
 </row>
 ```

--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -97,8 +97,8 @@ Collapsing a row removes the gutters from every column, which is the spacing bet
 
 ```inky_example
 <row class="collapse">
-  <columns large="6"><img src="https://placehold.it/300x150/777777/&text=These columns touch" alt=""></columns>
-  <columns large="6"><img src="https://placehold.it/300x150/999999/&text=These columns touch" alt=""></columns>
+  <columns large="6"><img src="https://via.placeholder.com/300x150/777777/&text=These columns touch" alt=""></columns>
+  <columns large="6"><img src="https://via.placeholder.com/300x150/999999/&text=These columns touch" alt=""></columns>
 </row>
 ```
 
@@ -112,7 +112,7 @@ Use the class `.large-offset-n` to create an offset, where `n` is the amount of 
 
 ```inky_example
 <row>
-  <columns large="3" class="large-offset-3"><img src="https://placehold.it/150x150/999999/&text=offset column" alt=""></columns>
-  <columns large="3"><img src="https://placehold.it/150x150/999999" alt=""></columns>
+  <columns large="3" class="large-offset-3"><img src="https://via.placeholder.com/150x150/999999/&text=offset column" alt=""></columns>
+  <columns large="3"><img src="https://via.placeholder.com/150x150/999999" alt=""></columns>
 </row>
 ```

--- a/docs/pages/thumbnail.md
+++ b/docs/pages/thumbnail.md
@@ -9,11 +9,11 @@ The `.thumbnail` class can be applied directly to an `<img>` element, or an `<a>
 The thumbnail style adds padding and a box shadow to an image. To use it, just add the class `.thumbnail` to an image element.
 
 ```inky_example
-<img src="https://placehold.it/200x200" class="thumbnail">
+<img src="https://via.placeholder.com/200x200" class="thumbnail">
 ```
 
 <!-- <table class="thumbnail">
   <tr>
-    <td><img src="//placehold.it/300x300" class="thumbnail" /></td>
+    <td><img src="//via.placeholder.com/300x300" class="thumbnail" /></td>
   </tr>
 </table> -->

--- a/docs/pages/wrapper.md
+++ b/docs/pages/wrapper.md
@@ -54,7 +54,7 @@ Creating a fluid header with the `<wrapper>` component is pretty straight forwar
   <container>
     <row class="collapse">
       <columns small="6" valign="middle">
-        <img src="https://placehold.it/200x50/663399">
+        <img src="https://via.placeholder.com/200x50/663399">
       </columns>
       <columns small="6" valign="middle">
         <p class="text-right">BASIC</p>

--- a/templates/basic.html
+++ b/templates/basic.html
@@ -33,7 +33,7 @@
   <container>
     <row class="collapse">
       <columns small="6" valign="middle">
-        <img src="http://placehold.it/200x50/663399">
+        <img src="http://via.placeholder.com/200x50/663399">
       </columns>
       <columns small="6" valign="middle">
         <p class="text-right">BASIC</p>

--- a/templates/drip.html
+++ b/templates/drip.html
@@ -21,7 +21,7 @@
 <container class="header">
   <row class="collapse">
     <columns>
-      <img src="http://placehold.it/150x30/663399" alt="">
+      <img src="http://via.placeholder.com/150x30/663399" alt="">
     </columns>
   </row>
 </container>
@@ -31,7 +31,7 @@
   <spacer size="16"></spacer>
 
   <center>
-    <img src="http://placehold.it/120/663399" alt="">
+    <img src="http://via.placeholder.com/120/663399" alt="">
   </center>
 
   <spacer size="16"></spacer>
@@ -61,11 +61,11 @@
       <a href="#">hello@nocopywrite.com</a> | <a href="#">Manage Email Notifications</a> | <a href="#">Unsubscribe</a></p>
       <center>
         <menu>
-          <item><img src="http://placehold.it/25/663399" alt=""></item>
-          <item><img src="http://placehold.it/25/663399" alt=""></item>
-          <item><img src="http://placehold.it/25/663399" alt=""></item>
-          <item><img src="http://placehold.it/25/663399" alt=""></item>
-          <item><img src="http://placehold.it/25/663399" alt=""></item>
+          <item><img src="http://via.placeholder.com/25/663399" alt=""></item>
+          <item><img src="http://via.placeholder.com/25/663399" alt=""></item>
+          <item><img src="http://via.placeholder.com/25/663399" alt=""></item>
+          <item><img src="http://via.placeholder.com/25/663399" alt=""></item>
+          <item><img src="http://via.placeholder.com/25/663399" alt=""></item>
         </menu>
       </center>
     </columns>

--- a/templates/hero.html
+++ b/templates/hero.html
@@ -32,7 +32,7 @@
   <container>
     <row class="collapse">
       <columns small="6">
-        <img src="http://placehold.it/200x50/663399">
+        <img src="http://via.placeholder.com/200x50/663399">
       </columns>
       <columns small="6">
         <p class="text-right">HERO</p>
@@ -49,7 +49,7 @@
     <columns small="12">
       <h1>Hi, Elijah Baily</h1>
       <p class="lead">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nisi impedit sapiente delectus molestias quia.</p>
-      <img src="http://placehold.it/548x300" alt="">
+      <img src="http://via.placeholder.com/548x300" alt="">
       <callout class="primary">
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam assumenda, praesentium qui vitae voluptate dolores. <a href="#">Click it!</a></p>
       </callout>

--- a/templates/marketing.html
+++ b/templates/marketing.html
@@ -14,7 +14,7 @@
   <row>
     <columns large="4">
       <center>
-        <img src="http://placehold.it/125x200">
+        <img src="http://via.placeholder.com/125x200">
       </center>
     </columns>
     <columns large="8">
@@ -34,21 +34,21 @@
   <row>
     <columns large="4">
       <center>
-        <img src="http://placehold.it/50x50">
+        <img src="http://via.placeholder.com/50x50">
       </center>
       <h5 class="text-center">Feature One</h5>
       <p class="text-center">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Rerum, quod quam unde earum.</p>
     </columns>
     <columns large="4">
       <center>
-        <img src="http://placehold.it/50x50">
+        <img src="http://via.placeholder.com/50x50">
       </center>
       <h5 class="text-center">Feature Two</h5>
       <p class="text-center">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Rerum, quod quam unde earum.</p>
     </columns>
     <columns large="4">
       <center>
-        <img src="http://placehold.it/50x50">
+        <img src="http://via.placeholder.com/50x50">
       </center>
       <h5 class="text-center">Feature Three</h5>
       <p class="text-center">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Rerum, quod quam unde earum.</p>
@@ -74,11 +74,11 @@
       <a href="#">hello@nocopywrite.com</a> | <a href="#">Manage Email Notifications</a> | <a href="#">Unsubscribe</a></p>
       <center>
         <menu>
-          <item><img src="http://placehold.it/25" alt=""></item>
-          <item><img src="http://placehold.it/25" alt=""></item>
-          <item><img src="http://placehold.it/25" alt=""></item>
-          <item><img src="http://placehold.it/25" alt=""></item>
-          <item><img src="http://placehold.it/25" alt=""></item>
+          <item><img src="http://via.placeholder.com/25" alt=""></item>
+          <item><img src="http://via.placeholder.com/25" alt=""></item>
+          <item><img src="http://via.placeholder.com/25" alt=""></item>
+          <item><img src="http://via.placeholder.com/25" alt=""></item>
+          <item><img src="http://via.placeholder.com/25" alt=""></item>
         </menu>
       </center>
     </columns>

--- a/templates/newsletter-2.html
+++ b/templates/newsletter-2.html
@@ -16,7 +16,7 @@
   <row>
     <columns>
       <center>
-        <img src="http://placehold.it/548x200">
+        <img src="http://via.placeholder.com/548x200">
       </center>
     </columns>
   </row>
@@ -27,7 +27,7 @@
       <p><a href="#">Learn more</a></p>
     </columns>
     <columns large="4">
-      <img class="small-float-center" src="http://placehold.it/170x129" width="170" alt="">
+      <img class="small-float-center" src="http://via.placeholder.com/170x129" width="170" alt="">
     </columns>
   </row>
   <row>

--- a/templates/newsletter.html
+++ b/templates/newsletter.html
@@ -15,7 +15,7 @@
     <columns>
       <h1 class="text-center">The Insider</h1>
       <center>
-        <img src="http://placehold.it/500x200">
+        <img src="http://via.placeholder.com/500x200">
       </center>
 
       <spacer size="16"></spacer>

--- a/templates/order.html
+++ b/templates/order.html
@@ -71,7 +71,7 @@
   </row>
   <row class="footer text-center">
     <columns large="3">
-      <img src="http://placehold.it/170x30" alt="">
+      <img src="http://via.placeholder.com/170x30" alt="">
     </columns>
     <columns large="3">
       <p>

--- a/templates/password.html
+++ b/templates/password.html
@@ -29,7 +29,7 @@
       <spacer size="32"></spacer>
 
       <center>
-        <img src="http://placehold.it/250x250">
+        <img src="http://via.placeholder.com/250x250">
       </center>
 
       <spacer size="16"></spacer>

--- a/templates/sidebar-hero.html
+++ b/templates/sidebar-hero.html
@@ -34,7 +34,7 @@
   <container>
     <row class="collapse">
       <columns small="6" valign="middle">
-        <img src="http://placehold.it/200x50/663399">
+        <img src="http://via.placeholder.com/200x50/663399">
       </columns>
       <columns small="6" valign="middle">
         <p class="text-right">Sidebar Hero</p>
@@ -52,7 +52,7 @@
       <h1>Hi, Elijah Baily</h1>
       <p class="lead">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nisi impedit sapiente delectus molestias quia.</p>
       <center>
-        <img src="http://placehold.it/548x300" alt="">
+        <img src="http://via.placeholder.com/548x300" alt="">
       </center>
       <callout class="primary">
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam assumenda, praesentium qui vitae voluptate dolores. <a href="#">Click it!</a></p>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -34,7 +34,7 @@
   <container>
     <row class="collapse">
       <columns small="6" valign="middle">
-        <img src="http://placehold.it/200x50/663399">
+        <img src="http://via.placeholder.com/200x50/663399">
       </columns>
       <columns small="6" valign="middle">
         <p class="text-right">Sidebar</p>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -42,7 +42,7 @@
       <spacer size="32"></spacer>
 
       <center>
-        <img src="http://placehold.it/200x200">
+        <img src="http://via.placeholder.com/200x200">
       </center>
 
       <spacer size="16"></spacer>

--- a/test/visual/pages/alignment.html
+++ b/test/visual/pages/alignment.html
@@ -30,13 +30,13 @@
       <br/>
       <p>Center on all clients</p>
       <center>
-        <img src="http://placehold.it/200?text=center" alt="">
+        <img src="http://via.placeholder.com/200?text=center" alt="">
       </center>
       <br/>
       <p>Center on all clients except Outlook 2007, 10, 13</p>
-      <img class="float-center" src="http://placehold.it/200?text=center" alt="">
-      <img class="float-right" src="http://placehold.it/200?text=right" alt="">
-      <img class="float-left" src="http://placehold.it/200?text=left" alt="">
+      <img class="float-center" src="http://via.placeholder.com/200?text=center" alt="">
+      <img class="float-right" src="http://via.placeholder.com/200?text=right" alt="">
+      <img class="float-left" src="http://via.placeholder.com/200?text=left" alt="">
       
     </columns>
   </row>
@@ -49,7 +49,7 @@
         <columns small="12" large="12">
         <p>Center on all (nested columns)</p>
           <center>
-            <img src="http://placehold.it/200?text=center" alt="">
+            <img src="http://via.placeholder.com/200?text=center" alt="">
           </center>
         </columns>
       </row>
@@ -64,13 +64,13 @@
         <columns small="6" large="6">
           <p>Center on all (nested columns)</p>
           <center>
-            <img src="http://placehold.it/200?text=center" alt="">
+            <img src="http://via.placeholder.com/200?text=center" alt="">
           </center>
         </columns>
         <columns small="6" large="6">
           <p>Center on all (nested columns)</p>
           <center>
-            <img src="http://placehold.it/200?text=center" alt="">
+            <img src="http://via.placeholder.com/200?text=center" alt="">
           </center>
         </columns>
       </row>
@@ -110,7 +110,7 @@
         <h3 class="small-text-center">Presentations<span>8</span></h3>
         <spacer size="35"></spacer>
         <center>
-          <img src="http://placehold.it/74x50">
+          <img src="http://via.placeholder.com/74x50">
         </center>
         <spacer size="40"></spacer>
       </callout>

--- a/test/visual/pages/attributes.html
+++ b/test/visual/pages/attributes.html
@@ -5,7 +5,7 @@
   the row should have dir="rtl"
   <row dir="rtl">
     <columns large="4" valign="middle" align="center">
-      <img class="small-float-center" src="http://placehold.it/300x200/345" alt="">
+      <img class="small-float-center" src="http://via.placeholder.com/300x200/345" alt="">
     </columns>
     <columns large="8">
       <h4>HEADLINE</h4>
@@ -15,7 +15,7 @@
 
   <row>
     <columns large="4" valign="middle">
-      <img class="small-float-center" src="http://placehold.it/300x200/621" alt="">
+      <img class="small-float-center" src="http://via.placeholder.com/300x200/621" alt="">
     </columns>
     <columns large="8">
       <h4>HEADLINE</h4>
@@ -27,7 +27,7 @@
 
   <row dir="rtl">
     <columns large="4" valign="middle" align="center">
-      <img class="small-float-center" src="http://placehold.it/250/349" alt="">
+      <img class="small-float-center" src="http://via.placeholder.com/250/349" alt="">
     </columns>
     <columns large="8" valign="middle" align="center">
       <h4 style="margin-bottom: 0;" class="text-right">HEADLINE</h4>

--- a/test/visual/pages/expander.html
+++ b/test/visual/pages/expander.html
@@ -3,7 +3,7 @@ Test for image that shrinks in Outlook 2000, 2002, 2003. This is caused by the u
 <container>
   <row>
     <columns small="12" large="3" class="large-offset-1">
-      <img class="small-float-center" src="http://placehold.it/200?text=small-center" alt="please don't forget me">
+      <img class="small-float-center" src="http://via.placeholder.com/200?text=small-center" alt="please don't forget me">
     </columns>
     <columns small="12" large="8">
       <h4 class="small-text-center">What is the deal?</h4>

--- a/test/visual/pages/fluid-header.html
+++ b/test/visual/pages/fluid-header.html
@@ -7,7 +7,7 @@
     <container class="header-container">
       <row class="collapse">
         <columns small="6" valign="middle">
-          <img src="http://placehold.it/200x50/663399">
+          <img src="http://via.placeholder.com/200x50/663399">
         </columns>
         <columns small="6" valign="middle" style="table-layout: fixed;">
           <p class="text-right">BASIC</p>

--- a/test/visual/pages/grid-collapse.html
+++ b/test/visual/pages/grid-collapse.html
@@ -6,10 +6,10 @@
   </row>
   <row class="collapse">
     <columns small="6" large="6">
-      <img src="http://placehold.it/300" alt="">
+      <img src="http://via.placeholder.com/300" alt="">
     </columns>
     <columns small="6" large="6">
-      <img src="http://placehold.it/300" alt="">
+      <img src="http://via.placeholder.com/300" alt="">
     </columns>
   </row>
   <row class="">
@@ -19,10 +19,10 @@
   </row>
   <row class="">
     <columns small="6" large="6">
-      <img src="http://placehold.it/300" alt="">
+      <img src="http://via.placeholder.com/300" alt="">
     </columns>
     <columns small="6" large="6">
-      <img src="http://placehold.it/300" alt="">
+      <img src="http://via.placeholder.com/300" alt="">
     </columns>
   </row>
 </container>

--- a/test/visual/pages/images.html
+++ b/test/visual/pages/images.html
@@ -1,27 +1,27 @@
 <container>
   <row>
     <columns small="12" large="12">
-      <img style="width: 14px;" src="http://placehold.it/600" alt="">
+      <img style="width: 14px;" src="http://via.placeholder.com/600" alt="">
     </columns>
   </row>
 
   <row>
     <columns small="12" large="12">
-      <img style="width: 480px;" src="http://placehold.it/600" alt="">
+      <img style="width: 480px;" src="http://via.placeholder.com/600" alt="">
     </columns>
   </row>
 
   <row>
     <columns small="12" large="12">
-      <img src="http://placehold.it/600" alt="">
+      <img src="http://via.placeholder.com/600" alt="">
     </columns>
   </row>
   <row>
     <columns small="12" large="6">
-      <img src="http://placehold.it/400" alt="">
+      <img src="http://via.placeholder.com/400" alt="">
     </columns>
     <columns small="12" large="6">
-      <img src="http://placehold.it/400" alt="">
+      <img src="http://via.placeholder.com/400" alt="">
     </columns>
   </row>
 </container>

--- a/test/visual/pages/layout-break-center.html
+++ b/test/visual/pages/layout-break-center.html
@@ -8,7 +8,7 @@
       <row class="no-padding-b">
         <columns small="6" large="6">
           <a href="http://google.com" title="" target="_blank">
-            <img class="small-float-center" src="http://placehold.it/580x600" width="290" height="300" alt="">
+            <img class="small-float-center" src="http://via.placeholder.com/580x600" width="290" height="300" alt="">
           </a>
           <p class="text-center"><span class="name text-center">Name of Product</span></p>
 
@@ -23,7 +23,7 @@
     </columns>
     <columns small="6" large="6">
       <a href="http://google.com" title="" target="_blank">
-        <img class="small-float-center" src="http://placehold.it/580x600" width="290" height="300" alt="">
+        <img class="small-float-center" src="http://via.placeholder.com/580x600" width="290" height="300" alt="">
       </a>
       <p class="text-center">
       <span class="name text-center">

--- a/test/visual/pages/outlook-image-width.html
+++ b/test/visual/pages/outlook-image-width.html
@@ -6,7 +6,7 @@
       <p><a href="#">Learn more</a></p>
     </columns>
     <columns class="test" large="4">
-      <img src="http://placehold.it/170x129" alt="">
+      <img src="http://via.placeholder.com/170x129" alt="">
     </columns>
   </row>
 </container>

--- a/test/visual/pages/spacer.html
+++ b/test/visual/pages/spacer.html
@@ -1,19 +1,19 @@
 <container>
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error atque, tempore illo nobis. Iure delectus eveniet ut, eaque molestias necessitatibus dicta, eos quidem ex maxime neque quae, fugiat temporibus amet.</p>
   <spacer size="32"></spacer>
-  <img src="http://placehold.it/32" alt="">
+  <img src="http://via.placeholder.com/32" alt="">
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur nisi error, labore porro reiciendis est, voluptate quasi exercitationem ad sed, odio, rem quos nostrum beatae consequatur. Velit accusantium, quo alias!</p>
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error atque, tempore illo nobis. Iure delectus eveniet ut, eaque molestias necessitatibus dicta, eos quidem ex maxime neque quae, fugiat temporibus amet.</p>
   <spacer size="66"></spacer>
-  <img src="http://placehold.it/66" alt="">
+  <img src="http://via.placeholder.com/66" alt="">
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur nisi error, labore porro reiciendis est, voluptate quasi exercitationem ad sed, odio, rem quos nostrum beatae consequatur. Velit accusantium, quo alias!</p>
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error atque, tempore illo nobis. Iure delectus eveniet ut, eaque molestias necessitatibus dicta, eos quidem ex maxime neque quae, fugiat temporibus amet.</p>
   <spacer size="99"></spacer>
-  <img src="http://placehold.it/99" alt="">
+  <img src="http://via.placeholder.com/99" alt="">
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur nisi error, labore porro reiciendis est, voluptate quasi exercitationem ad sed, odio, rem quos nostrum beatae consequatur. Velit accusantium, quo alias!</p>
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error atque, tempore illo nobis. Iure delectus eveniet ut, eaque molestias necessitatibus dicta, eos quidem ex maxime neque quae, fugiat temporibus amet.</p>
   <spacer size="120"></spacer>
-  <img src="http://placehold.it/120" alt="">
+  <img src="http://via.placeholder.com/120" alt="">
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur nisi error, labore porro reiciendis est, voluptate quasi exercitationem ad sed, odio, rem quos nostrum beatae consequatur. Velit accusantium, quo alias!</p>
 </container>
 

--- a/test/visual/pages/thumbnail.html
+++ b/test/visual/pages/thumbnail.html
@@ -2,32 +2,32 @@
   <row>
     <columns>
       <center>
-        <img src="http://placehold.it/800x300" alt="" class="thumbnail">
+        <img src="http://via.placeholder.com/800x300" alt="" class="thumbnail">
       </center>
     </columns>
   </row>
   <row>
     <columns>
       <center>
-        <img src="http://placehold.it/300x300" alt="" class="thumbnail">
+        <img src="http://via.placeholder.com/300x300" alt="" class="thumbnail">
       </center>
     </columns>
   </row>
   watch out for smacing issues on the full width thumbnails. The right side spacing should match left.
   <row>
     <columns small="6">
-      <img src="http://placehold.it/300x300" alt="" class="thumbnail">
+      <img src="http://via.placeholder.com/300x300" alt="" class="thumbnail">
     </columns>
     <columns small="6">
-      <img src="http://placehold.it/300x300" alt="" class="thumbnail">
+      <img src="http://via.placeholder.com/300x300" alt="" class="thumbnail">
     </columns>
   </row>
   <row>
     <columns large="6">
-      <img src="http://placehold.it/300x300" alt="" class="thumbnail">
+      <img src="http://via.placeholder.com/300x300" alt="" class="thumbnail">
     </columns>
     <columns large="6">
-      <img src="http://placehold.it/300x300" alt="" class="thumbnail">
+      <img src="http://via.placeholder.com/300x300" alt="" class="thumbnail">
     </columns>
   </row>
 </container>

--- a/test/visual/pages/visibility.html
+++ b/test/visual/pages/visibility.html
@@ -8,17 +8,17 @@
 
   <row>
     <columns small="6" large="4">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">name</p>
       <p class="text-center">age</p>
     </columns>
     <columns small="6" large="4">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">name</p>
       <p class="text-center">age</p>
     </columns>
     <columns small="6" large="4" class="show-for-large">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">show large</p>
       <p class="text-center">age</p>
     </columns>
@@ -26,17 +26,17 @@
 
   <row>
     <columns small="6" large="4">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">name</p>
       <p class="text-center">age</p>
     </columns>
     <columns small="6" large="4">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">name</p>
       <p class="text-center">age</p>
     </columns>
     <columns small="6" large="4" class="show-for-large">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">show large</p>
       <p class="text-center">age</p>
     </columns>
@@ -44,17 +44,17 @@
 
   <row>
     <columns small="6" large="4">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">name</p>
       <p class="text-center">age</p>
     </columns>
     <columns small="6" large="4">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">name</p>
       <p class="text-center">age</p>
     </columns>
     <columns small="6" large="4" class="show-for-large">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">show large</p>
       <p class="text-center">age</p>
     </columns>
@@ -62,12 +62,12 @@
 
   <row class="hide-for-large">
     <columns small="6" large="6">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">show small</p>
       <p class="text-center">age</p>
     </columns>
     <columns small="6" large="6">
-      <img align="center" class="float-center" src="http://placehold.it/120" alt="image of a cute kitty">
+      <img align="center" class="float-center" src="http://via.placeholder.com/120" alt="image of a cute kitty">
       <p class="text-center">show small</p>
       <p class="text-center">age</p>
     </columns>


### PR DESCRIPTION
## What?

Placeholder images are currently pointing to http://placehold.it , an external service that changed its url, so images are broken in templates.

![screen shot 2018-04-11 at 19 06 44](https://user-images.githubusercontent.com/3439783/38631957-89bd8f6e-3dbb-11e8-9cfc-ee56dc485e9b.png)

## How to test?

Check placeholder images are currently pointing to http://via.placeholder.com rather than http://placehold.it
