### PR TITLE
Fixed typo for Back to the Future reference

### DIFF
--- a/docs/pages/tips-tricks.md
+++ b/docs/pages/tips-tricks.md
@@ -16,7 +16,7 @@ A framework is a collection of reusable code and design patterns which gives use
 
 ## Need to know
 
-The sad truth about creating or coding HTML emails is that tables are the only things that are universally supported when it comes to email design. If you came from the world of building websites, this may seem like a stepping into Doc Brown's Delorean, charging up the Flux-capitor, and going back to the 1996. Suddenly your CSS is written with inline style tags, useful CSS properties don't work and you're burried in a sea of table tags.
+The sad truth about creating or coding HTML emails is that tables are the only things that are universally supported when it comes to email design. If you came from the world of building websites, this may seem like a stepping into Doc Brown's Delorean, charging up the Flux-capacitor, and going back to the 1996. Suddenly your CSS is written with inline style tags, useful CSS properties don't work and you're burried in a sea of table tags.
 
 <div class="callout secondary tip">General rule of thumb: your email is not going to look identical in every client. And that’s OK.</div>
 


### PR DESCRIPTION
The reference of Back to the Future fell a little flat when the typo "capitor" stood in for "capacitor". Don't worry Doc didn't see it, yet!

Before submitting a pull request, make sure it's targeting the right branch:

- For fixes to Ink 1.0, use `master`.
- For fixes to Foundation for Emails 2, use `v2.0`.

Happy coding! :)
