### PR TITLE
chore: upgrade gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-prompt": "^0.1.2",
     "gulp-rename": "^1.2.2",
     "gulp-rsync": "0.0.5",
-    "gulp-sass": "^2.1.0",
+    "gulp-sass": "^4.0.2",
     "gulp-sass-lint": "^1.1.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-wrap": "^0.11.0",


### PR DESCRIPTION
This upgrades the Sass dependency to support current Node.js releases.