### PR TITLE
Reuse the css variable

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -211,7 +211,7 @@ gulp.task('dist', ['sass:foundation'], function() {
 });
 
 function inliner(css) {
-  var css = fs.readFileSync(css).toString();
+  css = fs.readFileSync(css).toString();
   var mqCss = siphon(css);
 
   var pipe = lazypipe()


### PR DESCRIPTION
This PR reuses the `css` variable / parameter instead of creating redeclaring it as it is already declared / defined.