### PR TITLE
Set the global color for the header

### DIFF
--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -57,7 +57,7 @@ $block-grid-gutter: $global-gutter;
 $global-font-color: $black;
 $body-font-family: Helvetica, Arial, sans-serif;
 $global-font-weight: normal;
-$header-color: inherit;
+$header-color: $global-font-color;
 $global-line-height: 130%;
 $global-font-size: 16px;
 $body-line-height: $global-line-height;


### PR DESCRIPTION
When I send two letters one after another, the header color was inherited from Google style
