### PR TITLE
FIX: valign attribute not respected

### DIFF
--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -82,5 +82,10 @@ table, tr, td, th {
   padding-right: 0;
   padding-bottom: 0;
   padding-left: 0;
+  vertical-align: top;
   text-align: left;
+}
+
+table, tr, td:not([valign]), th:not([valign]) {
+  vertical-align: top;
 }

--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -82,6 +82,5 @@ table, tr, td, th {
   padding-right: 0;
   padding-bottom: 0;
   padding-left: 0;
-  vertical-align: top;
   text-align: left;
 }

--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -82,7 +82,6 @@ table, tr, td, th {
   padding-right: 0;
   padding-bottom: 0;
   padding-left: 0;
-  vertical-align: top;
   text-align: left;
 }
 


### PR DESCRIPTION
_normalize.scss hardcoded `vertical-align: top;` for `td` and `th`. This breaks setting `<column valign="bottom>"`.
