### PR TITLE
Fix broken links pointing to v2.0 branch tree

### DIFF
--- a/docs/pages/inky.md
+++ b/docs/pages/inky.md
@@ -49,7 +49,7 @@ Essentially, it is just custom HTML tags. Things like `<row>` and `<columns>` ar
 
 **How does it work?**
 
-We run a Gulp task that runs through your code, identifies our custom Inky tags, and translates them into valid HTML. For the more tech-savvy, you can [check out our task on our Github Repo](https://github.com/zurb/foundation-emails/blob/master/gulpfile.js#L149).
+We run a Gulp task that runs through your code, identifies our custom Inky tags, and translates them into valid HTML. For the more tech-savvy, you can [check out our task on our Github Repo](https://github.com/foundation/foundation-emails/blob/v2.0.0/gulpfile.js#L149).
 
 <a id="how-to-inky"></a>
 **How do I start Inky?**

--- a/docs/pages/inky.md
+++ b/docs/pages/inky.md
@@ -49,7 +49,7 @@ Essentially, it is just custom HTML tags. Things like `<row>` and `<columns>` ar
 
 **How does it work?**
 
-We run a Gulp task that runs through your code, identifies our custom Inky tags, and translates them into valid HTML. For the more tech-savvy, you can [check out our task on our Github Repo](https://github.com/zurb/foundation-emails/blob/v2.0/gulpfile.js#L149).
+We run a Gulp task that runs through your code, identifies our custom Inky tags, and translates them into valid HTML. For the more tech-savvy, you can [check out our task on our Github Repo](https://github.com/zurb/foundation-emails/blob/master/gulpfile.js#L149).
 
 <a id="how-to-inky"></a>
 **How do I start Inky?**

--- a/migration.md
+++ b/migration.md
@@ -458,4 +458,4 @@ The menu component can be used to create a simple set of links comonly used in h
 - Git
 - Node
 
-To use the Sass version with the Inky markup language you'll want to insall the Foundation for Emails project template. You'll find the [installation instructions here](https://github.com/zurb/foundation-emails#getting-started).
+To use the Sass version with the Inky markup language you'll want to insall the Foundation for Emails project template. You'll find the [installation instructions here](https://github.com/foundation/foundation-emails#getting-started).

--- a/migration.md
+++ b/migration.md
@@ -458,4 +458,4 @@ The menu component can be used to create a simple set of links comonly used in h
 - Git
 - Node
 
-To use the Sass version with the Inky markup language you'll want to insall the Foundation for Emails project template. You'll find the [installation instructions here](https://github.com/zurb/foundation-emails/tree/v2.0#getting-started).
+To use the Sass version with the Inky markup language you'll want to insall the Foundation for Emails project template. You'll find the [installation instructions here](https://github.com/zurb/foundation-emails#getting-started).


### PR DESCRIPTION
- Fix broken link to #getting-started in
  https://github.com/foundation/foundation-emails/blob/master/migration.md
  Find link by: "You'll find the installation instructions here."

- Fix broken link to gulpfile.js in
  https://get.foundation/emails/docs/inky.html#faq
  Find link by: "check out our task on our Github Repo"