### PR TITLE
<small> styling fix

### DIFF
--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -295,7 +295,7 @@ p {
   }
 }
 
-small
+small,
 .small {
   font-size: $small-font-size;
   color: $small-font-color;


### PR DESCRIPTION
Styling was not being implemented unless the structure was
```
<small>
    <element class="small"></element>
</small>
```
