### PR TITLE
Update padding in _menu.scss

### DIFF
--- a/docs/pages/typography.md
+++ b/docs/pages/typography.md
@@ -69,5 +69,5 @@ Links are very standard, and the color is preset to the Foundation primary color
 Use dividers to define thematic breaks between paragraphs or sections of your email.
 
 ```html
-<hr/>
+<h-line></h-line>
 ```

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -23,8 +23,10 @@ table.menu {
 
   td.menu-item,
   th.menu-item {
-    padding: $menu-item-padding;
+    padding-top: $menu-item-padding;
     padding-right: $menu-item-gutter;
+    padding-bottom: $menu-item-padding;
+    padding-left: $menu-item-padding;
 
     a {
       color: $menu-item-color;
@@ -36,8 +38,10 @@ table.menu {
 table.menu.vertical {
   td.menu-item,
   th.menu-item {
-    padding: $menu-item-padding;
+    padding-top: $menu-item-padding;
     padding-right: 0;
+    padding-bottom: $menu-item-padding;
+    padding-left: $menu-item-padding;
     display: block;
 
     a {

--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -163,7 +163,7 @@ $remove-ios-blue: true !default;
 /// @param {String} $width  - Width of divider
 /// @param {String} $border - Shorthand border style for divider
 /// @param {String} $margin - Margin above and below divider
-@mixin h-line($align: $hr-align, $width: $hr-width, $border: $hr-border, $margin: nth($hr-margin, 1)) {
+@mixin h-line($align: $hr-align, $width: $hr-width, $border: $hr-border, $margin: $hr-margin) {
   @at-root {
     td.columns & table,
     td.column  & table,
@@ -190,7 +190,7 @@ $remove-ios-blue: true !default;
       Margin: 0;
     }
 
-      td {
+      th {
         width: $width;
         height: 0;
         padding-top: $margin;


### PR DESCRIPTION
menu-item padding is not respected on production as th,td padding is direction explicit. Adding explicit directions to padding for menu-items resolves the issue

Before submitting a pull request, make sure it's targeting the right branch:

- For fixes to Ink 1.0, use `master`.
- For fixes to Foundation for Emails 2, use `v2.0`.

Happy coding! :)
