### PR TITLE
Fix deprecated elseif syntax

### DIFF
--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -177,7 +177,7 @@ $remove-ios-blue: true !default;
     padding-bottom: $margin;
     @if $align == 'left' {
       text-align: left;
-    } @elseif $align == 'right' {
+    } @else if $align == 'right' {
       text-align: right;
     } @else {
       text-align: center;


### PR DESCRIPTION
Syntax `@elseif` gives me deprecation warning:

```txt
DEPRECATION WARNING on line 180, column 7 of node_modules\foundation-emails\scss\components\_typography.scss:
@elseif is deprecated and will not be supported in future Sass versions.
Use "@else if" instead.
    ╷
180 │     } @elseif $align == 'right' {
    │       ^^^^^^^
    ╵
```
