### PR TITLE
FIX: center aligned items in horizontal menus

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -70,6 +70,10 @@ table.menu.text-center a {
   width: auto;
 }
 
+.menu[align="center"] tr {
+  text-align: center;
+}
+
 // Remove outside padding so that the menu aligns with other elements on the page
 .menu:not(.float-center) {
     .menu-item:first-child{padding-left:0!important;}


### PR DESCRIPTION
This is relevant for situations when the size of the centered horizontal menu is bigger then the container and items start stacking - occurs only on mobile.

Without fix:
<img width="200" alt="Screenshot 2020-08-03 at 23 23 21" src="https://user-images.githubusercontent.com/25999449/89229056-023afe80-d5e1-11ea-99d2-8348f07428c7.png">

With fix:
<img width="200" alt="Screenshot 2020-08-03 at 23 25 25" src="https://user-images.githubusercontent.com/25999449/89229064-09620c80-d5e1-11ea-8af2-2374b255b09c.png">

