### PR TITLE
ReFIX for PR/1002 (vertical-alignment fix)

### DIFF
--- a/scss/components/_alignment.scss
+++ b/scss/components/_alignment.scss
@@ -85,4 +85,20 @@ th {
   }
 }
 
+td.columns,
+td.column,
+th.columns,
+th.column {
+  &[valign="bottom"] {
+    vertical-align: bottom;
+  }
+}
 
+td.columns,
+td.column,
+th.columns,
+th.column {
+  &[valign="middle"] {
+    vertical-align: middle;
+  }
+}

--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -82,6 +82,6 @@ table, tr, td, th {
   padding-right: 0;
   padding-bottom: 0;
   padding-left: 0;
-  text-align: left;
   vertical-align: top;
+  text-align: left;
 }

--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -82,5 +82,10 @@ table, tr, td, th {
   padding-right: 0;
   padding-bottom: 0;
   padding-left: 0;
+  vertical-align: top;
   text-align: left;
+}
+
+table, tr, td:not([valign]), th:not([valign]) {
+  vertical-align: top;
 }

--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -83,8 +83,5 @@ table, tr, td, th {
   padding-bottom: 0;
   padding-left: 0;
   text-align: left;
-}
-
-table, tr, td:not([valign]), th:not([valign]) {
   vertical-align: top;
 }

--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -82,6 +82,5 @@ table, tr, td, th {
   padding-right: 0;
   padding-bottom: 0;
   padding-left: 0;
-  vertical-align: top;
   text-align: left;
 }

--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -82,7 +82,6 @@ table, tr, td, th {
   padding-right: 0;
   padding-bottom: 0;
   padding-left: 0;
-  vertical-align: top;
   text-align: left;
 }
 


### PR DESCRIPTION
Vertical alignment fix that doesn't change the _normalize file ( firstly proposed at #1002 ) and adds vertical-alignment styles correctly on _alignment.scss