### PR TITLE
docs: add link to thumbnail component

### DIFF
--- a/docs/partials/component-list.html
+++ b/docs/partials/component-list.html
@@ -27,8 +27,9 @@
   <li><a href="grid.html">Grid</a></li>
   <li><a href="menu.html">Menu</a></li>
   <li><a href="spacer.html">Spacer</a></li>
-  <li><a href="wrapper.html">Wrapper</a></li>
+  <li><a href="thumbnail.html">Thumbnail</a></li>
   <li><a href="typography.html">Typography</a></li>
+  <li><a href="wrapper.html">Wrapper</a></li>
   <li><a href="visibility.html">Visibility Classes</a></li>
 
   <li class="docs-nav-title">Libraries</li>


### PR DESCRIPTION
I noticed that while the page existed there was not a link to it. Currently, the only way. to get to it is via searching.