### PR TITLE
Revert "fixed marked rendering"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ sass.compiler = require('node-sass');
 supercollider
   .config({
     template: foundationDocs.componentTemplate,
-    marked: foundationDocs.marked.mdRenderer,
+    marked: foundationDocs.marked,
     handlebars: foundationDocs.handlebars,
     keepFm: true,
     quiet: false,


### PR DESCRIPTION
This reverts commit adef9048082a8a676564131dc1c56559d5dc7f46.

The change obviously broke the whole markup rendering so we have to revert it.
