### PR TITLE
Update sass-guide.md

### DIFF
--- a/docs/pages/sass-guide.md
+++ b/docs/pages/sass-guide.md
@@ -23,6 +23,8 @@ In this Getting Started guide, we'll download Foundation for Emails, construct t
 ## Requirements
 
 To use the Sass version of Foundation for Emails, you need Node.js installed on your computer. Node is compatible with Windows, OS X, and Linux&mdash;the [Node.js website](https://nodejs.org/) has installers for every operating system.
+**Current Node.js that is supported is 10 or less.**
+
 
 ---
 


### PR DESCRIPTION
https://get.foundation/emails/docs/sass-guide.html#installing
while following the docs the steps outline how to install foundation emails using npm.
there is no mention of required versions of Node.js however after install i receive error when trying to create new project

I expected that a new project would be created in the folder the command was executed.

the following is the error:
```
usr-MacBook-Pro-:ui usr$ foundation new --framework email
fs.js:35
} = primordials;
    ^

ReferenceError: primordials is not defined
    at fs.js:35:5
    at req_ (/usr/local/lib/node_modules/foundation-cli/node_modules/natives/index.js:143:24)
    at Object.req [as require] (/usr/local/lib/node_modules/foundation-cli/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (/usr/local/lib/node_modules/foundation-cli/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
    at require (internal/modules/cjs/helpers.js:72:18)

```
Running Node.js v12.18.0.


as per stack exchange: 
[https://stackoverflow.com/questions/56245622/foundation-referenceerror-primordials-is-not-defined-when-starting-a-foundat](https://stackoverflow.com/questions/56245622/foundation-referenceerror-primordials-is-not-defined-when-starting-a-foundat)

NodeJS 12 is not supported by the current CLI. Please use NodeJS 10.



The docs should be updated to indicate the version of Node.js that is supported. Make it easier for people to get started 💯

Before submitting a pull request, make sure it's targeting the right branch:

- For fixes to Ink 1.0, use `master`.
- For fixes to Foundation for Emails 2, use `v2.0`.

Happy coding! :)
