### PR TITLE
Add style box-sizing: border-box  to _normalize.scss

### DIFF
--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -75,6 +75,9 @@ td, th {
   -moz-hyphens: auto;
   hyphens: auto;
   border-collapse: collapse !important;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 table, tr, td, th {


### PR DESCRIPTION
  Hello! In some email app (for example [Mail.ru - Email App](https://play.google.com/store/apps/details?id=ru.mail.mailapp&hl=en)   ) you will see broken letter for template **newsletter-2.html** 
![Screenshot from 2020-09-11 12-22-18](https://user-images.githubusercontent.com/21157352/92905922-bd4e8700-f42c-11ea-8af7-12c6382659bc.png)

