### PR TITLE
use shorthand padding in base styles

### DIFF
--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -78,10 +78,7 @@ td, th {
 }
 
 table, tr, td, th {
-  padding-top: 0;
-  padding-right: 0;
-  padding-bottom: 0;
-  padding-left: 0;
+  padding: 0;
   vertical-align: top;
   text-align: left;
 }

--- a/scss/components/_typography.scss
+++ b/scss/components/_typography.scss
@@ -218,10 +218,7 @@ th {
   color: $global-font-color;
   font-family: $body-font-family;
   font-weight: $global-font-weight;
-  padding-top: 0;
-  padding-right: 0;
-  padding-bottom: 0;
-  padding-left: 0;
+  padding: 0;
   margin: 0;
   Margin: 0;
   text-align: left;


### PR DESCRIPTION
A fix for https://github.com/foundation/foundation-emails/issues/1031

All individual paddings are picked up and in-lined so the later styles for callouts and anything that uses shorthand later on in the CSS are not effective.

BEFORE:
<img width="872" alt="Screenshot 2020-09-25 at 10 27 07" src="https://user-images.githubusercontent.com/33517841/94256763-2e5c6700-ff22-11ea-853c-297d87fac842.png">


AFTER:
<img width="820" alt="Screenshot 2020-09-25 at 10 25 47" src="https://user-images.githubusercontent.com/33517841/94256796-3a482900-ff22-11ea-9681-31cb6fc8f210.png">


Testi.at
https://testi.at/proj/g46TbDCB3tXbPUGqXtly5
<img width="1267" alt="Screenshot 2020-09-25 at 11 25 23" src="https://user-images.githubusercontent.com/33517841/94256823-446a2780-ff22-11ea-94bc-773df9944a78.png">


