### PR TITLE
Add composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "foundation/foundation-emails",
+    "description": "A framework for responsive emails",
+    "keywords": [
+      "responsive",
+      "emails"
+    ],
+    "homepage": "https://get.foundation",
+    "authors": [
+      {
+        "name": "Foundation",
+        "homepage": "https://get.foundation",
+        "email": "contact@get.foundation"
+      }
+    ],
+    "support": {
+      "email": "contact@get.foundation",
+      "issues": "https://github.com/foundation/foundation-emails/issues",
+      "forum": "https://github.com/foundation/foundation-emails/discussions"
+    },
+    "license": "MIT"
+  }
+  


### PR DESCRIPTION
This PR adds a composer.json file that allows foundation-emails to be registered with Packagist, the main Composer repository, which aggregates all sorts of PHP packages that are installable with Composer.

For consistency with foundation-sites: https://github.com/foundation/foundation-sites/blob/develop/composer.json

Metadata (description, author, ...) extracted from package.json

Fix #817

Once merged, you'll need a packagist account (https://packagist.org/) and register the repository