### PR TITLE
callout: separated the padding to make it work in outlook

### DIFF
--- a/scss/components/_callout.scss
+++ b/scss/components/_callout.scss
@@ -58,7 +58,10 @@ table.callout {
 th.callout-inner {
   width: 100%;
   border: $callout-border;
-  padding: $callout-padding;
+  padding-top: $callout-padding;
+  padding-right: $callout-padding;
+  padding-bottom: $callout-padding;
+  padding-left: $callout-padding;
   background: $callout-background;
 
   &.primary {


### PR DESCRIPTION
outlook does not recognize padding shorthand